### PR TITLE
Packer improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/packer.R
+++ b/R/packer.R
@@ -335,8 +335,8 @@ monty_packer <- function(scalar = NULL, array = NULL, fixed = NULL,
     ## anything else.
     shp <- pack_check_dimensions(p, scalar, shape, names(fixed), process)
     ret <- matrix(NA_real_, len, prod(shp))
-    for (i in seq_along(p)) {
-      ret[idx[[i]], ] <- p[[i]]
+    for (nm in c(scalar, names(shape))) {
+      ret[idx[[nm]], ] <- p[[nm]]
     }
 
     drop <- length(shp) == 0 ||
@@ -420,7 +420,6 @@ print.monty_packer <- function(x, ...) {
 unpack_vector <- function(x, parameters, len, idx, shape, fixed, process) {
   call <- parent.frame()
   if (!is.null(names(x))) {
-    browser()
     if (!identical(names(x), parameters)) {
       ## Here, we could do better I think with this message; we
       ## might pass thropuigh empty names, and produce some summary
@@ -513,7 +512,7 @@ pack_check_dimensions <- function(p, scalar, shape, fixed, process,
 
   err <- setdiff(names(shape), names(p))
   if (length(err) > 0) {
-    cli::cli_abort("Name{?s} missing from input to pack: {squote(err)}",
+    cli::cli_abort("Missing element{?s} from input to pack: {squote(err)}",
                    call = call)
   }
   if (length(extra) > 0) {

--- a/R/packer.R
+++ b/R/packer.R
@@ -499,7 +499,7 @@ unpack_array <- function(x, parameters, len, idx, shape, fixed, process) {
 
 
 ## Now, we do some annoying calculations to make sure that what we've
-## been gven has the correct size, etc.
+## been given has the correct size, etc.
 pack_check_dimensions <- function(p, scalar, shape, fixed, process,
                                   call = parent.frame()) {
   if (length(scalar) > 0) {
@@ -525,14 +525,14 @@ pack_check_dimensions <- function(p, scalar, shape, fixed, process,
   ## single pack.  What we expect is if we have an element 'x' with
   ## dimensions <a, b, c, ...> and we expect that the shape 's' of
   ## this is <a, b> we need to validate that the first dimensions of
-  ## 'x' are 's' and thern record the remainder - that's the shape of
+  ## 'x' are 's' and then record the remainder - that's the shape of
   ## the rest of the eventual object (so if there is no dimension left
   ## then it was originally a vector, if there's one element left our
   ## original input was a matrix and so on).  Then we check that this
   ## remainder is consistent across all elements in the list.
   ##
   ## There are a couple of additional wrinkles due to scalar variables
-  ## (these are ones where 's' has length 0).  First, We can't drop
+  ## (these are ones where 's' has length 0).  First, we can't drop
   ## things from 'd' with d[-i] because that will drop everything.
   ## Second, when working out the residual dimensions of the packed
   ## data we might have a situation where there are some scalars for

--- a/R/packer.R
+++ b/R/packer.R
@@ -318,7 +318,7 @@ prepare_pack_array <- function(name, shape, call = NULL) {
       arg = "array", call = call)
   }
   if (length(shape) == 0) {
-    return(list(names = name, shape = 1, n = 1L))
+    return(list(names = name, shape = integer(0), n = 1L))
   }
   if (any(shape <= 0)) {
     cli::cli_abort(

--- a/R/packer.R
+++ b/R/packer.R
@@ -129,7 +129,7 @@
 ##'
 ##' The input to `pack()` will be the shape that `unpack()` returned;
 ##' a named list of numerical vectors, matrices and arrays.  The names
-##' must correspond do the names if your packer (i.e., `scalar` and
+##' must correspond to the names in your packer (i.e., `scalar` and
 ##' the names of `array`).  Each element has dimensions
 ##'
 ##' ```

--- a/R/util.R
+++ b/R/util.R
@@ -102,7 +102,7 @@ dim2 <- function(x) {
 
 
 "dim2<-" <- function(x, value) {
-  if (length(value) != 1) {
+  if (length(value) > 1) {
     dim(x) <- value
   }
   x

--- a/man/monty_packer.Rd
+++ b/man/monty_packer.Rd
@@ -166,10 +166,36 @@ matrices (one column per set) and so on.
 
 This approach generalises to higher dimensional input, though we
 suspect you'll spend a bit of time head-scratching if you use it.
+}
 
-We do not currently offer the ability to pack this sort of output
-back up, though it's not hard.  Please let us know if you would
-use this.
+\section{Packing lists into vectors and matrices}{
+The unpacking operation is very common - an MCMC proceeds,
+produces an unstructured vector, and you unpack it into a list in
+order to be able to easily work with it.  The reverse is much less
+common, where we take a list and convert it into a vector (or
+matrix, or multidimensional array).  Use of this direction
+("packing") may be more common where using packers to work with
+the output of state-space models (e.g. in
+\href{https://mrc-ide.github.io/odin2}{odin2} or
+\href{https://mrc-ide.github.io/dust2}{dust2}, which use this
+machinery).
+
+The input to \code{pack()} will be the shape that \code{unpack()} returned;
+a named list of numerical vectors, matrices and arrays.  The names
+must correspond do the names if your packer (i.e., \code{scalar} and
+the names of \code{array}).  Each element has dimensions
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{<...object, ...residual>
+}\if{html}{\out{</div>}}
+
+where \code{...object} is the dimensions of the data itself and
+\code{...residual} is the dimensions of the hypothetical input to
+\code{pack}.
+
+There is an unfortunate ambiguity in R's lack of true scalar types
+that we cannot avoid.  It is hard to tell the difference packing a
+vector vs packing an array where all dimensions are 1.  See the
+examples, and please let us know if the behaviour needs changing.
 }
 
 \examples{
@@ -214,4 +240,19 @@ p$unpack(1:4)
 # The processed elements are ignored on the return pack:
 p$pack(list(a = 1, b_flat = 2:4, b = matrix(c(2, 3, 3, 4), 2, 2)))
 p$pack(list(a = 1, b_flat = 2:4))
+
+# R lacks scalars, which means that some packers will unpack
+# different inputs to the same outputs:
+p <- monty_packer(c("a", "b"))
+p$unpack(1:2)
+p$unpack(cbind(1:2))
+
+# This means that we can't reliably pack these inputs in a way
+# that guarantees round-tripping is possible.  We have chosen to
+# prioritise the case where a *single vector* is round-trippable:
+p$pack(list(a = 1, b = 2))
+
+# This ambiguity goes away if unpacking matices with more than one
+# column:
+p$unpack(matrix(1:6, 2, 3))
 }

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -238,7 +238,7 @@ test_that("Properly unpack scalars stored as zero-length arrays", {
 ## These tests are the inverse of the tests abvove.
 test_that("Roundtrip scalars stored as zero-length arrays", {
   p <- monty_packer(array = list(a = integer(0), b = 1L))
-  p$pack(list(a = 1, b = 2))
+  expect_equal(p$pack(list(a = 1, b = 2)), c(1, 2))
 
   ## expect_equal(p$unpack(1:2), list(a = 1, b = 2))
   expect_equal(p$pack(list(a = 1, b = 2)), c(1, 2))

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -220,3 +220,15 @@ test_that("can't used process with array unpacking", {
     p$unpack(matrix(1:6, 2)),
     "Can't unpack a matrix where the unpacker uses 'process'")
 })
+
+
+test_that("Properly unpack scalars stored as zero-length arrays", {
+  p <- monty_packer(array = list(a = integer(0), b = 1L))
+  expect_equal(p$unpack(1:2), list(a = 1, b = 2))
+  expect_equal(p$unpack(matrix(1:10, 2, 5)),
+               list(a = seq(1, 9, by = 2),
+                    b = matrix(seq(2, 10, by = 2), 1, 5)))
+  expect_equal(p$unpack(array(1:30, c(2, 3, 5))),
+               list(a = matrix(seq(1, 29, by = 2), c(3, 5)),
+                    b = array(seq(2, 30, by = 2), c(1, 3, 5))))
+})


### PR DESCRIPTION
The first commit (7aa5a234c22d04cabaa71f2781be6826b393ff7a) fixes a small bug that I noticed when working with dust to unpack output from dust models, where we were treating "scalars" created via the `array` argument slightly differently to those created via the `scalar` argument.

The next couple of commits, and the bulk of this PR fixes a problem I noticed working with this, where we simply don't support packing multidimensional inputs.  I don't think we'll do this very often but it felt like the current implementation was not good enough.  This is surprisingly horrible to do, and I think that's reflected in the error messages and help files.   This is something I feel we'll improve on over time.
