### PR TITLE
Allow chain thinning/burnin while running

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.23
+Version: 0.2.24
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE := $(shell grep '^Package:' DESCRIPTION | sed -E 's/^Package:[[:space:]]+//')
-RSCRIPT = Rscript --no-init-file
+RSCRIPT = Rscript
 
 all:
 	${RSCRIPT} -e 'pkgbuild::compile_dll()'

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -32,10 +32,10 @@ monty_runner_simultaneous <- function(progress = NULL) {
       call = environment())
   }
 
-  run <- function(pars, model, sampler, n_steps, rng) {
+  run <- function(pars, model, sampler, steps, rng) {
     validate_suitable(model)
     n_chains <- length(rng)
-    pb <- progress_bar(n_chains, n_steps, progress, show_overall = FALSE)
+    pb <- progress_bar(n_chains, n_steps$total, progress, show_overall = FALSE)
     progress <- pb(seq_len(n_chains))
     rng_state <- lapply(rng, function(r) r$state())
     ## TODO: get the rng state back into 'rng' here, or (better) look
@@ -45,16 +45,16 @@ monty_runner_simultaneous <- function(progress = NULL) {
     ## >   rng[[i]]$set_state(rng_state[, i]) # not supported!
     ## > }
     monty_run_chains_simultaneous(pars, model, sampler,
-                                  n_steps, progress, rng_state)
+                                  steps, progress, rng_state)
   }
 
-  continue <- function(state, model, sampler, n_steps) {
+  continue <- function(state, model, sampler, steps) {
     validate_suitable(model)
     n_chains <- length(state)
-    pb <- progress_bar(n_chains, n_steps, progress, show_overall = FALSE)
+    pb <- progress_bar(n_chains, steps$total, progress, show_overall = FALSE)
     progress <- pb(seq_len(n_chains))
     monty_continue_chains_simultaneous(state, model, sampler,
-                                       n_steps, progress)
+                                       steps, progress)
   }
 
   monty_runner("Simultaneous",
@@ -74,7 +74,7 @@ monty_runner_simultaneous <- function(progress = NULL) {
 ##   hard to avoid.
 ## * there's quite a lot of churn around rng state
 monty_run_chains_simultaneous <- function(pars, model, sampler,
-                                          n_steps, progress, rng_state) {
+                                          steps, progress, rng_state) {
   r_rng_state <- get_r_rng_state()
   n_chains <- length(rng_state)
   rng <- monty_rng$new(unlist(rng_state), n_chains)
@@ -82,12 +82,12 @@ monty_run_chains_simultaneous <- function(pars, model, sampler,
   chain_state <- sampler$initialise(pars, model, rng)
 
   monty_run_chains_simultaneous2(chain_state, model, sampler,
-                                 n_steps, progress, rng, r_rng_state)
+                                 steps, progress, rng, r_rng_state)
 }
 
 
 monty_continue_chains_simultaneous <- function(state, model, sampler,
-                                               n_steps, progress) {
+                                               steps, progress) {
   r_rng_state <- get_r_rng_state()
   n_chains <- length(state)
   n_pars <- length(model$parameters)
@@ -111,21 +111,22 @@ monty_continue_chains_simultaneous <- function(state, model, sampler,
   ## Need to use model$rng_state$set to put state$model_rng into the model
 
   monty_run_chains_simultaneous2(chain_state, model, sampler,
-                                 n_steps, progress, rng, r_rng_state)
+                                 steps, progress, rng, r_rng_state)
 }
 
 
 monty_run_chains_simultaneous2 <- function(chain_state, model, sampler,
-                                           n_steps, progress, rng,
+                                           steps, progress, rng,
                                            r_rng_state) {
   initial <- chain_state$pars
   n_pars <- length(model$parameters)
   n_chains <- length(chain_state$density)
+  n_steps_record <- steps$total
 
-  history_pars <- array(NA_real_, c(n_pars, n_steps, n_chains))
-  history_density <- matrix(NA_real_, n_steps, n_chains)
+  history_pars <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
+  history_density <- matrix(NA_real_, n_steps_record, n_chains)
 
-  for (i in seq_len(n_steps)) {
+  for (i in seq_len(steps$total)) {
     chain_state <- sampler$step(chain_state, model, rng)
     history_pars[, i, ] <- chain_state$pars
     history_density[i, ] <- chain_state$density

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -35,7 +35,7 @@ monty_runner_simultaneous <- function(progress = NULL) {
   run <- function(pars, model, sampler, steps, rng) {
     validate_suitable(model)
     n_chains <- length(rng)
-    pb <- progress_bar(n_chains, n_steps$total, progress, show_overall = FALSE)
+    pb <- progress_bar(n_chains, steps$total, progress, show_overall = FALSE)
     progress <- pb(seq_len(n_chains))
     rng_state <- lapply(rng, function(r) r$state())
     ## TODO: get the rng state back into 'rng' here, or (better) look

--- a/R/runner.R
+++ b/R/runner.R
@@ -200,7 +200,7 @@ monty_run_chain2 <- function(chain_state, model, sampler, steps,
   n_pars <- length(model$parameters)
   has_observer <- model$properties$has_observer
 
-  n_steps_record <- steps$total
+  n_steps_record <- steps$total - steps$burnin
 
   history_pars <- matrix(NA_real_, n_pars, n_steps_record)
   history_density <- rep(NA_real_, n_steps_record)
@@ -209,10 +209,12 @@ monty_run_chain2 <- function(chain_state, model, sampler, steps,
 
   for (i in seq_len(steps$total)) {
     chain_state <- sampler$step(chain_state, model, rng)
-    history_pars[, i] <- chain_state$pars
-    history_density[[i]] <- chain_state$density
-    if (has_observer && !is.null(chain_state$observation)) {
-      history_observation[[i]] <- chain_state$observation
+    if (i > burnin) {
+      history_pars[, i] <- chain_state$pars
+      history_density[[i]] <- chain_state$density
+      if (has_observer && !is.null(chain_state$observation)) {
+        history_observation[[i]] <- chain_state$observation
+      }
     }
     progress(i)
   }

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -59,10 +59,11 @@
 ##' # Clean up samples
 ##' monty_sample_manual_cleanup(path)
 monty_sample_manual_prepare <- function(model, sampler, n_steps, path,
-                                        initial = NULL, n_chains = 1L) {
+                                        initial = NULL, n_chains = 1L,
+                                        burnin = NULL) {
   ## This break exists to hide the 'seed' argument from the public
   ## interface.  We will use this from the callr version though.
-  steps <- monty_sample_steps(n_steps)
+  steps <- monty_sample_steps(n_steps, burnin)
   sample_manual_prepare(model, sampler, steps, path, initial, n_chains)
 }
 
@@ -282,8 +283,9 @@ sample_manual_info_chain <- function(complete) {
 ##'
 ##' @export
 ##' @inherit monty_sample_manual_prepare return
-monty_sample_manual_prepare_continue <- function(samples, steps, path,
+monty_sample_manual_prepare_continue <- function(samples, n_steps, path,
                                                  save_samples = "hash") {
+  steps <- monty_sample_steps(n_steps, burnin = NULL)
   ## I am not terribly happy wih the function name here, something for
   ## the review?
   ##

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -60,10 +60,10 @@
 ##' monty_sample_manual_cleanup(path)
 monty_sample_manual_prepare <- function(model, sampler, n_steps, path,
                                         initial = NULL, n_chains = 1L,
-                                        burnin = NULL) {
+                                        burnin = NULL, thinning_factor = NULL) {
   ## This break exists to hide the 'seed' argument from the public
   ## interface.  We will use this from the callr version though.
-  steps <- monty_sample_steps(n_steps, burnin)
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
   sample_manual_prepare(model, sampler, steps, path, initial, n_chains)
 }
 
@@ -188,7 +188,8 @@ monty_sample_manual_collect <- function(path, samples = NULL,
   }
 
   if (restartable) {
-    samples$restart <- restart_data(res, inputs$model, inputs$sampler, NULL)
+    samples$restart <- restart_data(res, inputs$model, inputs$sampler, NULL,
+                                    inputs$steps$thinning_factor)
   }
   samples
 }
@@ -285,13 +286,16 @@ sample_manual_info_chain <- function(complete) {
 ##' @inherit monty_sample_manual_prepare return
 monty_sample_manual_prepare_continue <- function(samples, n_steps, path,
                                                  save_samples = "hash") {
-  steps <- monty_sample_steps(n_steps, burnin = NULL)
   ## I am not terribly happy wih the function name here, something for
   ## the review?
   ##
   ## also not happy with save_samples = "nothing"
   restart <- samples$restart
   samples <- sample_manual_prepare_check_samples(samples, save_samples)
+
+  steps <- monty_sample_steps(n_steps,
+                              burnin = NULL,
+                              thinning_factor = restart$thinning_factor)
 
   dat <- list(restart = restart,
               n_chains = length(restart$state),

--- a/R/sample.R
+++ b/R/sample.R
@@ -40,7 +40,7 @@
 ##'   the first `burnin` steps.  Generally you would want to do this
 ##'   in post-processing as this data is discarded with no chance of
 ##'   getting it back.  However, if your observation process creates a
-##'   large amount of data, then you pay prefer to apply a burnin here
+##'   large amount of data, then you may prefer to apply a burnin here
 ##'   to reduce how much memory is used.
 ##'
 ##' @param thinning_factor A thinning factor to apply while the chain

--- a/R/sample.R
+++ b/R/sample.R
@@ -35,6 +35,14 @@
 ##'   restartable.  This will add additional data to the chains
 ##'   object.
 ##'
+##' @param burnin Number of steps to discard as burnin.  This affects
+##'   only the recording of steps as your chains run; we don't record
+##'   the first `burnin` steps.  Generally you would want to do this
+##'   in post-processing as this data is discarded with no chance of
+##'   getting it back.  However, if your observation process creates a
+##'   large amount of data, then you pay prefer to apply a burnin here
+##'   to reduce how much memory is used.
+##'
 ##' @return A list of parameters and densities.  We provide conversion
 ##'   to formats used by other packages, notably
 ##'   [posterior::as_draws_array], [posterior::as_draws_df] and

--- a/R/sample.R
+++ b/R/sample.R
@@ -43,6 +43,19 @@
 ##'   large amount of data, then you pay prefer to apply a burnin here
 ##'   to reduce how much memory is used.
 ##'
+##' @param thinning_factor A thinning factor to apply while the chain
+##'   is running.  If given, then we save every `thinning_factor`'th
+##'   step.  So if `thinning_factor = 2` we save every second step,
+##'   and if 10, we'd save every 10th.  Like `burnin` above, it is
+##'   preferable to apply this in post processing.  However, for
+##'   slow-mixing chains that have a large observer output you can use
+##'   this to reduce the memory usage.  Use of `thinning_factor`
+##'   requires that `n_steps` is an even multiple of
+##'   `thinning_factor`; so if `thinning_factor` is 10, then `n_steps`
+##'   must be a multiple of 10.  This ensures that the last step is in
+##'   the sample.  The thinning factor cannot be changed when
+##'   continuing a chain.
+##'
 ##' @return A list of parameters and densities.  We provide conversion
 ##'   to formats used by other packages, notably
 ##'   [posterior::as_draws_array], [posterior::as_draws_df] and
@@ -91,7 +104,8 @@
 ##' # diagnostics.
 monty_sample <- function(model, sampler, n_steps, initial = NULL,
                          n_chains = 1L, runner = NULL,
-                         restartable = FALSE, burnin = NULL) {
+                         restartable = FALSE, burnin = NULL,
+                         thinning_factor = NULL) {
   assert_is(model, "monty_model")
   assert_is(sampler, "monty_sampler")
   if (is.null(runner)) {
@@ -103,13 +117,14 @@ monty_sample <- function(model, sampler, n_steps, initial = NULL,
 
   rng <- initial_rng(n_chains)
   pars <- initial_parameters(initial, model, rng, environment())
-  steps <- monty_sample_steps(n_steps, burnin)
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
   res <- runner$run(pars, model, sampler, steps, rng)
 
   observer <- if (model$properties$has_observer) model$observer else NULL
   samples <- combine_chains(res, model$observer)
   if (restartable) {
-    samples$restart <- restart_data(res, model, sampler, runner)
+    samples$restart <- restart_data(res, model, sampler, runner,
+                                    thinning_factor)
   }
   samples
 }
@@ -157,7 +172,10 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
   state <- samples$restart$state
   model <- samples$restart$model
   sampler <- samples$restart$sampler
-  steps <- monty_sample_steps(n_steps, burnin = NULL)
+
+  burnin <- NULL
+  thinning_factor <- samples$restart$thinning_factor
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
 
   res <- runner$continue(state, model, sampler, steps)
 
@@ -165,7 +183,8 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
   samples <- append_chains(samples, combine_chains(res, observer), observer)
 
   if (restartable) {
-    samples$restart <- restart_data(res, model, sampler, runner)
+    samples$restart <- restart_data(res, model, sampler, runner,
+                                    thinning_factor)
   }
   samples
 }
@@ -372,7 +391,7 @@ initial_rng <- function(n_chains, seed = NULL) {
 }
 
 
-restart_data <- function(res, model, sampler, runner) {
+restart_data <- function(res, model, sampler, runner, thinning_factor) {
   if (is.null(names(res))) {
     state <- lapply(res, function(x) x$internal$state)
   } else {
@@ -392,7 +411,8 @@ restart_data <- function(res, model, sampler, runner) {
   list(state = state,
        model = model,
        sampler = sampler,
-       runner = runner)
+       runner = runner,
+       thinning_factor = thinning_factor)
 }
 
 
@@ -411,19 +431,34 @@ direct_sample_within_domain <- function(model, rng, max_attempts = 100) {
 }
 
 
-monty_sample_steps <- function(n_steps, burnin = NULL, call = parent.frame()) {
+monty_sample_steps <- function(n_steps, burnin = NULL, thinning_factor = NULL,
+                               call = parent.frame()) {
   if (inherits(n_steps, "monty_sample_steps")) {
     return(n_steps)
   }
   assert_scalar_size(n_steps, call = call)
-  if (!is.null(burnin)) {
-    assert_scalar_size(burnin, call = call)
+  if (is.null(burnin)) {
+    burnin <- 0
+  } else {
+    assert_scalar_size(burnin, allow_zero = TRUE, call = call)
     if (burnin >= n_steps) {
       cli::cli_abort("'burnin' must be smaller than 'n_steps'",
                      arg = "burnin", call = call)
     }
   }
-  ret <- list(total = n_steps, burnin = burnin)
+  if (is.null(thinning_factor)) {
+    thinning_factor <- 1
+  } else {
+    assert_scalar_size(thinning_factor, allow_zero = FALSE, call = call)
+    if (n_steps %% thinning_factor != 0) {
+      cli::cli_abort(
+        "'thinning_factor' must be a divisor of 'n_steps'",
+        call = call)
+    }
+  }
+  ret <- list(total = n_steps,
+              burnin = burnin,
+              thinning_factor = thinning_factor)
   class(ret) <- "monty_sample_steps"
   ret
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -95,7 +95,8 @@ monty_sample <- function(model, sampler, n_steps, initial = NULL,
 
   rng <- initial_rng(n_chains)
   pars <- initial_parameters(initial, model, rng, environment())
-  res <- runner$run(pars, model, sampler, n_steps, rng)
+  steps <- monty_sample_steps(n_steps)
+  res <- runner$run(pars, model, sampler, steps, rng)
 
   observer <- if (model$properties$has_observer) model$observer else NULL
   samples <- combine_chains(res, model$observer)
@@ -148,8 +149,9 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
   state <- samples$restart$state
   model <- samples$restart$model
   sampler <- samples$restart$sampler
+  steps <- monty_sample_steps(n_steps)
 
-  res <- runner$continue(state, model, sampler, n_steps)
+  res <- runner$continue(state, model, sampler, steps)
 
   observer <- if (model$properties$has_observer) model$observer else NULL
   samples <- append_chains(samples, combine_chains(res, observer), observer)
@@ -398,4 +400,14 @@ direct_sample_within_domain <- function(model, rng, max_attempts = 100) {
       i = paste("Your model's 'direct_sample()' method is generating",
                 "samples that fall outside your model's domain.  Probably",
                 "you should fix one or both of these!")))
+}
+
+
+monty_sample_steps <- function(n_steps) {
+  if (inherits(n_steps, "monty_sample_steps")) {
+    return(n_steps)
+  }
+  ret <- list(total = n_steps)
+  class(ret) <- "monty_sample_steps"
+  ret
 }

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -50,7 +50,7 @@ only the recording of steps as your chains run; we don't record
 the first \code{burnin} steps.  Generally you would want to do this
 in post-processing as this data is discarded with no chance of
 getting it back.  However, if your observation process creates a
-large amount of data, then you pay prefer to apply a burnin here
+large amount of data, then you may prefer to apply a burnin here
 to reduce how much memory is used.}
 
 \item{thinning_factor}{A thinning factor to apply while the chain

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -11,7 +11,8 @@ monty_sample(
   initial = NULL,
   n_chains = 1L,
   runner = NULL,
-  restartable = FALSE
+  restartable = FALSE,
+  burnin = NULL
 )
 }
 \arguments{
@@ -42,6 +43,14 @@ one chain then this argument is best left alone.}
 \item{restartable}{Logical, indicating if the chains should be
 restartable.  This will add additional data to the chains
 object.}
+
+\item{burnin}{Number of steps to discard as burnin.  This affects
+only the recording of steps as your chains run; we don't record
+the first \code{burnin} steps.  Generally you would want to do this
+in post-processing as this data is discarded with no chance of
+getting it back.  However, if your observation process creates a
+large amount of data, then you pay prefer to apply a burnin here
+to reduce how much memory is used.}
 }
 \value{
 A list of parameters and densities.  We provide conversion

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -12,7 +12,8 @@ monty_sample(
   n_chains = 1L,
   runner = NULL,
   restartable = FALSE,
-  burnin = NULL
+  burnin = NULL,
+  thinning_factor = NULL
 )
 }
 \arguments{
@@ -51,6 +52,19 @@ in post-processing as this data is discarded with no chance of
 getting it back.  However, if your observation process creates a
 large amount of data, then you pay prefer to apply a burnin here
 to reduce how much memory is used.}
+
+\item{thinning_factor}{A thinning factor to apply while the chain
+is running.  If given, then we save every \code{thinning_factor}'th
+step.  So if \code{thinning_factor = 2} we save every second step,
+and if 10, we'd save every 10th.  Like \code{burnin} above, it is
+preferable to apply this in post processing.  However, for
+slow-mixing chains that have a large observer output you can use
+this to reduce the memory usage.  Use of \code{thinning_factor}
+requires that \code{n_steps} is an even multiple of
+\code{thinning_factor}; so if \code{thinning_factor} is 10, then \code{n_steps}
+must be a multiple of 10.  This ensures that the last step is in
+the sample.  The thinning factor cannot be changed when
+continuing a chain.}
 }
 \value{
 A list of parameters and densities.  We provide conversion

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -10,7 +10,8 @@ monty_sample_manual_prepare(
   n_steps,
   path,
   initial = NULL,
-  n_chains = 1L
+  n_chains = 1L,
+  burnin = NULL
 )
 }
 \arguments{
@@ -43,6 +44,14 @@ sampling.  If not given, we sample from the model (or its prior).}
 
 \item{n_chains}{Number of chains to run.  The default is to run a
 single chain, but you will likely want to run more.}
+
+\item{burnin}{Number of steps to discard as burnin.  This affects
+only the recording of steps as your chains run; we don't record
+the first \code{burnin} steps.  Generally you would want to do this
+in post-processing as this data is discarded with no chance of
+getting it back.  However, if your observation process creates a
+large amount of data, then you pay prefer to apply a burnin here
+to reduce how much memory is used.}
 }
 \value{
 Invisibly, the path used to store files (the same as the

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -11,7 +11,8 @@ monty_sample_manual_prepare(
   path,
   initial = NULL,
   n_chains = 1L,
-  burnin = NULL
+  burnin = NULL,
+  thinning_factor = NULL
 )
 }
 \arguments{
@@ -52,6 +53,19 @@ in post-processing as this data is discarded with no chance of
 getting it back.  However, if your observation process creates a
 large amount of data, then you pay prefer to apply a burnin here
 to reduce how much memory is used.}
+
+\item{thinning_factor}{A thinning factor to apply while the chain
+is running.  If given, then we save every \code{thinning_factor}'th
+step.  So if \code{thinning_factor = 2} we save every second step,
+and if 10, we'd save every 10th.  Like \code{burnin} above, it is
+preferable to apply this in post processing.  However, for
+slow-mixing chains that have a large observer output you can use
+this to reduce the memory usage.  Use of \code{thinning_factor}
+requires that \code{n_steps} is an even multiple of
+\code{thinning_factor}; so if \code{thinning_factor} is 10, then \code{n_steps}
+must be a multiple of 10.  This ensures that the last step is in
+the sample.  The thinning factor cannot be changed when
+continuing a chain.}
 }
 \value{
 Invisibly, the path used to store files (the same as the

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -51,7 +51,7 @@ only the recording of steps as your chains run; we don't record
 the first \code{burnin} steps.  Generally you would want to do this
 in post-processing as this data is discarded with no chance of
 getting it back.  However, if your observation process creates a
-large amount of data, then you pay prefer to apply a burnin here
+large amount of data, then you may prefer to apply a burnin here
 to reduce how much memory is used.}
 
 \item{thinning_factor}{A thinning factor to apply while the chain


### PR DESCRIPTION
This PR allows thinning while the chain runs; this is primarily for cases where the observer will produce a lot of data.  To keep the general idea of the chain continuation working, the thinning rate cannot be changed after starting and you can only burnin the initial bit.  I think that later we might want to allow "continue but don't append" so that these things can be modified (same with things like changing the proposal)