### PR TITLE
Allow continuing chain without appending

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.26
+Version: 0.2.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -154,6 +154,7 @@ monty_sample_manual_run <- function(chain_id, path, progress = NULL) {
 ##' @title Collect manually run samples
 ##'
 ##' @inheritParams monty_sample_manual_run
+##' @inheritParams monty_sample_continue
 ##'
 ##' @param samples Samples from the parent run.  You need to provide
 ##'   these where `save_samples` was set to anything other than "value"

--- a/man/monty_sample_continue.Rd
+++ b/man/monty_sample_continue.Rd
@@ -4,7 +4,13 @@
 \alias{monty_sample_continue}
 \title{Continue sampling}
 \usage{
-monty_sample_continue(samples, n_steps, restartable = FALSE, runner = NULL)
+monty_sample_continue(
+  samples,
+  n_steps,
+  restartable = FALSE,
+  runner = NULL,
+  append = TRUE
+)
 }
 \arguments{
 \item{samples}{A \code{monty_samples} object created by
@@ -27,6 +33,9 @@ given, must be a \code{monty_runner} object such as
 use this argument to change the configuration of a runner, as
 well as the type of runner (e.g., changing the number of
 allocated cores).}
+
+\item{append}{Logical, indicating if we should append the results
+of the resumed chain together with the original chain.}
 }
 \value{
 A list of parameters and densities

--- a/man/monty_sample_manual_collect.Rd
+++ b/man/monty_sample_manual_collect.Rd
@@ -22,6 +22,9 @@ these where \code{save_samples} was set to anything other than "value"}
 restartable.  This will add additional data to the chains
 object.  Note that this is controlled at chain collection and
 not creation.}
+
+\item{append}{Logical, indicating if we should append the results
+of the resumed chain together with the original chain.}
 }
 \value{
 A \code{monty_samples} object.

--- a/man/monty_sample_manual_collect.Rd
+++ b/man/monty_sample_manual_collect.Rd
@@ -4,7 +4,12 @@
 \alias{monty_sample_manual_collect}
 \title{Collect manually run samples}
 \usage{
-monty_sample_manual_collect(path, samples = NULL, restartable = FALSE)
+monty_sample_manual_collect(
+  path,
+  samples = NULL,
+  restartable = FALSE,
+  append = TRUE
+)
 }
 \arguments{
 \item{path}{The path used in the call to

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -425,3 +425,19 @@ test_that("can continue thinned chain, continues thinning", {
 
   expect_equal(res2b, res1)
 })
+
+
+test_that("can choose not to append when continuing samples", {
+  model <- ex_simple_gamma1()
+  sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
+
+  set.seed(1)
+  res1 <- monty_sample(model, sampler, 100, 1, n_chains = 3)
+
+  set.seed(1)
+  res2a <- monty_sample(model, sampler, 60, 1, n_chains = 3,
+                          restartable = TRUE)
+  res2b <- monty_sample_continue(res2a, 40, append = FALSE)
+
+  expect_equal(res2b$pars, res1$pars[, 61:100, , drop = FALSE])
+})


### PR DESCRIPTION
Sometimes we'll want to a continue a chain but ignore the previous inputs (e.g., we can see that the previous chain has a massive bit of burnin and is not stationary).  This PR adds an arg to make this easy.

Another similar thing we don't have yet but which would be useful is one to convert samples into sensible input for new initial conditions and a vcv, possibly for a different number of chains; that is not done here