### PR TITLE
Proper closing of progress bars on failure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.28
+Version: 0.2.29
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/runner-callr.R
+++ b/R/runner-callr.R
@@ -71,7 +71,7 @@ monty_runner_callr <- function(n_workers, progress = NULL) {
           }
         }
       }
-      env$progress(env$n_steps_progress)
+      env$progress$update(env$n_steps_progress)
     }
 
     all(env$status == "done")
@@ -87,12 +87,14 @@ monty_runner_callr <- function(n_workers, progress = NULL) {
     env$result_path <- rep(NA_character_, n_chains)
     env$n_steps <- steps$total
     env$n_steps_progress <- rep(0, n_chains)
-    env$progress <- pb(seq_len(n_chains))
+    env$progress <- pb
     for (session_id in seq_len(n_workers)) {
       launch(session_id)
     }
-    while (!step()) {
-    }
+    with_progress_fail_on_error(
+      pb,
+      while (!step()) {
+      })
 
     res <- lapply(env$result_path, readRDS)
     unlink(env$path, recursive = TRUE)

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -128,6 +128,8 @@ monty_run_chains_simultaneous2 <- function(chain_state, model, sampler,
   history_pars <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
   history_density <- matrix(NA_real_, n_steps_record, n_chains)
 
+  chain_id <- seq_len(n_chains)
+
   for (i in seq_len(steps$total)) {
     chain_state <- sampler$step(chain_state, model, rng)
     history_pars[, i, ] <- chain_state$pars

--- a/R/runner.R
+++ b/R/runner.R
@@ -25,22 +25,26 @@ monty_runner_serial <- function(progress = NULL) {
   run <- function(pars, model, sampler, steps, rng) {
     n_chains <- length(rng)
     pb <- progress_bar(n_chains, steps$total, progress, show_overall = TRUE)
-    lapply(
-      seq_along(rng),
-      function(i) {
-        monty_run_chain(i, pars[, i], model, sampler, steps,
-                        pb(i), rng[[i]])
-      })
+    with_progress_fail_on_error(
+      pb,
+      lapply(
+        seq_along(rng),
+        function(i) {
+          monty_run_chain(i, pars[, i], model, sampler, steps,
+                          pb$update, rng[[i]])
+        }))
   }
 
   continue <- function(state, model, sampler, steps) {
     n_chains <- length(state)
     pb <- progress_bar(n_chains, steps$total, progress, show_overall = TRUE)
-    lapply(
-      seq_along(state),
-      function(i) {
-        monty_continue_chain(i, state[[i]], model, sampler, steps, pb(i))
-      })
+    with_progress_fail_on_error(
+      pb,
+      lapply(
+        seq_along(state),
+        function(i) {
+          monty_continue_chain(i, state[[i]], model, sampler, steps, pb$update)
+        }))
   }
 
   monty_runner("Serial",
@@ -130,7 +134,7 @@ monty_runner_parallel <- function(n_workers) {
     args <- list(model = model,
                  sampler = sampler,
                  steps = steps,
-                 progress = function(i) NULL)
+                 progress = progress_bar_none()$update)
     parallel::clusterMap(
       cl,
       monty_continue_chain,
@@ -149,7 +153,7 @@ monty_runner_parallel <- function(n_workers) {
 monty_run_chain_parallel <- function(chain_id, pars, model, sampler, steps,
                                      rng) {
   rng <- monty_rng$new(rng)
-  progress <- function(i) NULL
+  progress <- progress_bar_none()$update
   monty_run_chain(chain_id, pars, model, sampler, steps, progress, rng)
 }
 
@@ -224,7 +228,7 @@ monty_run_chain2 <- function(chain_id, chain_state, model, sampler, steps,
       }
       j <- j + 1L
     }
-    progress(i)
+    progress(chain_id, i)
   }
 
   ## Pop the parameter names on last

--- a/R/runner.R
+++ b/R/runner.R
@@ -7,11 +7,8 @@
 ##' @param progress Optional logical, indicating if we should print a
 ##'   progress bar while running.  If `NULL`, we use the value of the
 ##'   option `monty.progress` if set, otherwise we show the progress
-##'   bar (as it is typically wanted).  The progress bar itself
-##'   responds to cli's options; in particular
-##'   `cli.progress_show_after` and `cli.progress_clear` will affect
-##'   your experience.  Alternatively, you can provide a string
-##'   indicating the progress bar type.  Options are `fancy`
+##'   bar (as it is typically wanted).  Alternatively, you can provide
+##'   a string indicating the progress bar type.  Options are `fancy`
 ##'   (equivalent to `TRUE`), `none` (equivalent to `FALSE`) and
 ##'   `simple` (a very simple text-mode progress indicator designed
 ##'   play nicely with logging; it does not use special codes to clear

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -133,13 +133,15 @@ monty_sample_manual_run <- function(chain_id, path, progress = NULL) {
     state <- restart$state
     model <- restart$model
     sampler <- restart$sampler
-    res <- monty_continue_chain(state[[chain_id]], model, sampler, steps, pb)
+    res <- monty_continue_chain(chain_id, state[[chain_id]], model, sampler,
+                                steps, pb)
   } else {
     pars <- inputs$pars
     model <- inputs$model
     sampler <- inputs$sampler
     rng <- monty_rng$new(seed = inputs$rng_state[[chain_id]])
-    res <- monty_run_chain(pars[, chain_id], model, sampler, steps, pb, rng)
+    res <- monty_run_chain(chain_id, pars[, chain_id], model, sampler, steps,
+                           pb, rng)
   }
 
   saveRDS(res, path$results)

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -127,22 +127,25 @@ monty_sample_manual_run <- function(chain_id, path, progress = NULL) {
   is_continue <- is.list(restart)
 
   pb <- progress_bar(n_chains, steps$total, progress,
-                     show_overall = FALSE, single_chain = TRUE)(chain_id)
+                     show_overall = FALSE, single_chain = TRUE)
 
-  if (is_continue) {
-    state <- restart$state
-    model <- restart$model
-    sampler <- restart$sampler
-    res <- monty_continue_chain(chain_id, state[[chain_id]], model, sampler,
-                                steps, pb)
-  } else {
-    pars <- inputs$pars
-    model <- inputs$model
-    sampler <- inputs$sampler
-    rng <- monty_rng$new(seed = inputs$rng_state[[chain_id]])
-    res <- monty_run_chain(chain_id, pars[, chain_id], model, sampler, steps,
-                           pb, rng)
-  }
+  with_progress_fail_on_error(
+    pb,
+    if (is_continue) {
+      state <- restart$state
+      model <- restart$model
+      sampler <- restart$sampler
+      res <- monty_continue_chain(chain_id, state[[chain_id]], model, sampler,
+                                  steps, pb$update)
+    } else {
+      pars <- inputs$pars
+      model <- inputs$model
+      sampler <- inputs$sampler
+      rng <- monty_rng$new(seed = inputs$rng_state[[chain_id]])
+      res <- monty_run_chain(chain_id, pars[, chain_id], model, sampler, steps,
+                             pb$update, rng)
+    }
+  )
 
   saveRDS(res, path$results)
   invisible(path$results)

--- a/R/util.R
+++ b/R/util.R
@@ -219,3 +219,8 @@ callr_safe_result <- function(rs, grace = 2, dt = 0.1) {
 last <- function(x) {
   x[[length(x)]]
 }
+
+
+is_testing <- function() {
+  identical(Sys.getenv("TESTTHAT"), "true")
+}

--- a/man/monty_runner_callr.Rd
+++ b/man/monty_runner_callr.Rd
@@ -18,11 +18,8 @@ will likely be no faster than 4).}
 \item{progress}{Optional logical, indicating if we should print a
 progress bar while running.  If \code{NULL}, we use the value of the
 option \code{monty.progress} if set, otherwise we show the progress
-bar (as it is typically wanted).  The progress bar itself
-responds to cli's options; in particular
-\code{cli.progress_show_after} and \code{cli.progress_clear} will affect
-your experience.  Alternatively, you can provide a string
-indicating the progress bar type.  Options are \code{fancy}
+bar (as it is typically wanted).  Alternatively, you can provide
+a string indicating the progress bar type.  Options are \code{fancy}
 (equivalent to \code{TRUE}), \code{none} (equivalent to \code{FALSE}) and
 \code{simple} (a very simple text-mode progress indicator designed
 play nicely with logging; it does not use special codes to clear

--- a/man/monty_runner_serial.Rd
+++ b/man/monty_runner_serial.Rd
@@ -10,11 +10,8 @@ monty_runner_serial(progress = NULL)
 \item{progress}{Optional logical, indicating if we should print a
 progress bar while running.  If \code{NULL}, we use the value of the
 option \code{monty.progress} if set, otherwise we show the progress
-bar (as it is typically wanted).  The progress bar itself
-responds to cli's options; in particular
-\code{cli.progress_show_after} and \code{cli.progress_clear} will affect
-your experience.  Alternatively, you can provide a string
-indicating the progress bar type.  Options are \code{fancy}
+bar (as it is typically wanted).  Alternatively, you can provide
+a string indicating the progress bar type.  Options are \code{fancy}
 (equivalent to \code{TRUE}), \code{none} (equivalent to \code{FALSE}) and
 \code{simple} (a very simple text-mode progress indicator designed
 play nicely with logging; it does not use special codes to clear

--- a/man/monty_runner_simultaneous.Rd
+++ b/man/monty_runner_simultaneous.Rd
@@ -10,11 +10,8 @@ monty_runner_simultaneous(progress = NULL)
 \item{progress}{Optional logical, indicating if we should print a
 progress bar while running.  If \code{NULL}, we use the value of the
 option \code{monty.progress} if set, otherwise we show the progress
-bar (as it is typically wanted).  The progress bar itself
-responds to cli's options; in particular
-\code{cli.progress_show_after} and \code{cli.progress_clear} will affect
-your experience.  Alternatively, you can provide a string
-indicating the progress bar type.  Options are \code{fancy}
+bar (as it is typically wanted).  Alternatively, you can provide
+a string indicating the progress bar type.  Options are \code{fancy}
 (equivalent to \code{TRUE}), \code{none} (equivalent to \code{FALSE}) and
 \code{simple} (a very simple text-mode progress indicator designed
 play nicely with logging; it does not use special codes to clear

--- a/man/monty_sample_manual_run.Rd
+++ b/man/monty_sample_manual_run.Rd
@@ -18,11 +18,8 @@ provide an integer that does not correspond to a chain in 1 to
 \item{progress}{Optional logical, indicating if we should print a
 progress bar while running.  If \code{NULL}, we use the value of the
 option \code{monty.progress} if set, otherwise we show the progress
-bar (as it is typically wanted).  The progress bar itself
-responds to cli's options; in particular
-\code{cli.progress_show_after} and \code{cli.progress_clear} will affect
-your experience.  Alternatively, you can provide a string
-indicating the progress bar type.  Options are \code{fancy}
+bar (as it is typically wanted).  Alternatively, you can provide
+a string indicating the progress bar type.  Options are \code{fancy}
 (equivalent to \code{TRUE}), \code{none} (equivalent to \code{FALSE}) and
 \code{simple} (a very simple text-mode progress indicator designed
 play nicely with logging; it does not use special codes to clear

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,4 +1,0 @@
-withr::local_options(
-  monty.progress = FALSE,
-  .local_envir = teardown_env()
-)

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -1,4 +1,5 @@
 test_that("can select sensible values for progress", {
+  withr::local_envvar(TESTTHAT = FALSE)
   withr::with_options(list(monty.progress = TRUE), {
     expect_equal(show_progress_bar(FALSE), "none")
     expect_equal(show_progress_bar(TRUE), "fancy")
@@ -23,8 +24,8 @@ test_that("can select sensible values for progress", {
 
 
 test_that("null progress bar does nothing", {
-  p <- progress_bar(10, 10, FALSE)(1)
-  expect_silent(p(1))
+  p <- progress_bar(10, 10, FALSE)
+  expect_silent(p$update(1, 1))
 })
 
 
@@ -67,14 +68,13 @@ test_that("overall progress is empty if disabled", {
 
 
 test_that("can format fancy", {
-  f <- progress_bar_fancy(4, 100, TRUE)
-  g <- f(1)
+  f <- progress_bar_fancy(4, 100, TRUE)$update
   id <- environment(f)$id
   e <- environment(f)$e
 
   mock_update <- mockery::mock()
-  mockery::stub(g, "cli::cli_progress_update", mock_update)
-  g(5)
+  mockery::stub(f, "cli::cli_progress_update", mock_update)
+  f(1, 5)
   mockery::expect_called(mock_update, 1)
   expect_equal(mockery::mock_args(mock_update)[[1]],
                list(id = id, set = 5))
@@ -102,14 +102,13 @@ test_that("can create pb", {
 
 
 test_that("can create a simple progress bar", {
-  pb <- progress_bar_simple(104, 5)
-  p <- pb(1)
-  expect_message(p(10), "MONTY-PROGRESS: chain: 1, step: 10")
-  expect_no_message(p(11))
-  expect_message(p(36), "MONTY-PROGRESS: chain: 1, step: 36")
-  expect_message(p(102), "MONTY-PROGRESS: chain: 1, step: 102")
-  expect_no_message(p(103))
-  expect_message(p(104), "MONTY-PROGRESS: chain: 1, step: 104")
+  p <- progress_bar_simple(104, 5)$update
+  expect_message(p(1, 10), "MONTY-PROGRESS: chain: 1, step: 10")
+  expect_no_message(p(1, 11))
+  expect_message(p(1, 36), "MONTY-PROGRESS: chain: 1, step: 36")
+  expect_message(p(1, 102), "MONTY-PROGRESS: chain: 1, step: 102")
+  expect_no_message(p(1, 103))
+  expect_message(p(1, 104), "MONTY-PROGRESS: chain: 1, step: 104")
 })
 
 


### PR DESCRIPTION
A nice test case from Ed:

```
prior <- monty::monty_dsl({
  beta ~ Exponential(mean = 0.3)
  gamma ~ Exponential(mean = 0.1)
})

sir <- dust2::dust_example("sir")

data <- data.frame(cases = 3:22,
                   time = 1:20)

filter <- dust2::dust_filter_create(sir, 0, data, n_particles = 200)

sir_packer <- monty::monty_packer(c("beta", "gamma"), fixed = list(I0 = 5))

likelihood <- dust2::dust_likelihood_monty(filter, sir_packer)

posterior <- prior + likelihood

sampler <- monty::monty_sampler_random_walk(diag(2) * 0.02)

pars <- list(beta = 0.3, gamma = 0.1, I0 = 5)

samples <- monty::monty_sample(posterior, sampler, 1000,
                               initial = sir_packer$pack(pars),
                               n_chains = 4)
```

Run this and cancel the progress run half way through  (Ctrl-C/Esc on Rstudio) then run the sampling again.  you end up with something like:

```
> samples <- monty::monty_sample(posterior, sampler, 1000,
+                                initial = sir_packer$pack(pars),
+                                n_chains = 4)
Sampling [█▃▁▁] ■■■■■■■■■■■                      |  33% ETA:  4s
> samples <- monty::monty_sample(posterior, sampler, 1000,
+                                initial = sir_packer$pack(pars),
+                                n_chains = 4)
Sampling [█▃▁▁] ■■■■■■■■■■■                      |  33% ETA:  4s
```

with the last line appearing after *every* future progress call, not great!

This is because we use `.auto_close = FALSE` with the progress bars, so cli seems to think that the failed bar is the "current" bar and redraws it.

This PR fixes things by:

* using `show_after = 0` so bars turn up faster
* using clear = FALSE` so that they don't clear once done
* closing out any failed progress bar using `withCallingHandlers` and coping with both failure and interrupt