### PR TITLE
Allow using previous samples as initial conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.33
+Version: 0.2.34
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/sample.R
+++ b/R/sample.R
@@ -259,7 +259,7 @@ initial_parameters <- function(initial, model, rng, call = NULL) {
   if (inherits(initial, "monty_samples")) {
     ## Heuristic here; sample from the last 5% of the chain or 20
     ## points, whichever is smaller - hopefully a reasonable
-    ## heuristic.  Then sample
+    ## heuristic - pooled across chains.
     pars <- tail_and_pool(initial$pars, 0.05, 20)
     if (nrow(pars) != n_pars) {
       cli::cli_abort(

--- a/R/sample.R
+++ b/R/sample.R
@@ -260,7 +260,7 @@ initial_parameters <- function(initial, model, rng, call = NULL) {
     ## Heuristic here; sample from the last 5% of the chain or 20
     ## points, whichever is smaller - hopefully a reasonable
     ## heuristic.  Then sample
-    pars <- tail_and_pool(samples$pars, 0.05, 20)
+    pars <- tail_and_pool(initial$pars, 0.05, 20)
     if (nrow(pars) != n_pars) {
       cli::cli_abort(
         c(paste("Unexpected parameter length in 'monty_samples' object",

--- a/R/sample.R
+++ b/R/sample.R
@@ -24,7 +24,10 @@
 ##'   prior).  Alternatively, you can provide an `monty_samples`
 ##'   object here -- the result of a previous call to this function --
 ##'   and we will sample some starting points from the final portion
-##'   of the chains.
+##'   of the chains (the exact details here are subject to change, but
+##'   we'll sample from the last 20 points or 5% of the chain, which
+##'   ever smaller, with replacement, pooled across all chains in the
+##'   previous sample).
 ##'
 ##' @param n_chains Number of chains to run.  The default is to run a
 ##'   single chain, but you will likely want to run more.

--- a/R/sample.R
+++ b/R/sample.R
@@ -21,7 +21,7 @@
 ##'
 ##' @param initial Optionally, initial parameter values for the
 ##'   sampling.  If not given, we sample from the model (or its
-##'   prior).  Alternatively, you can provide an `monty_samples`
+##'   prior).  Alternatively, you can provide a `monty_samples`
 ##'   object here -- the result of a previous call to this function --
 ##'   and we will sample some starting points from the final portion
 ##'   of the chains (the exact details here are subject to change, but

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -30,7 +30,11 @@ sampler implemented is \code{\link[=monty_sampler_random_walk]{monty_sampler_ran
 \item{n_steps}{The number of steps to run the sampler for.}
 
 \item{initial}{Optionally, initial parameter values for the
-sampling.  If not given, we sample from the model (or its prior).}
+sampling.  If not given, we sample from the model (or its
+prior).  Alternatively, you can provide an \code{monty_samples}
+object here -- the result of a previous call to this function --
+and we will sample some starting points from the final portion
+of the chains.}
 
 \item{n_chains}{Number of chains to run.  The default is to run a
 single chain, but you will likely want to run more.}

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -34,7 +34,10 @@ sampling.  If not given, we sample from the model (or its
 prior).  Alternatively, you can provide an \code{monty_samples}
 object here -- the result of a previous call to this function --
 and we will sample some starting points from the final portion
-of the chains.}
+of the chains (the exact details here are subject to change, but
+we'll sample from the last 20 points or 5\% of the chain, which
+ever smaller, with replacement, pooled across all chains in the
+previous sample).}
 
 \item{n_chains}{Number of chains to run.  The default is to run a
 single chain, but you will likely want to run more.}

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -41,7 +41,11 @@ the process calling \code{monty_sample_manual_prepare} should outlive
 running all sampling.}
 
 \item{initial}{Optionally, initial parameter values for the
-sampling.  If not given, we sample from the model (or its prior).}
+sampling.  If not given, we sample from the model (or its
+prior).  Alternatively, you can provide an \code{monty_samples}
+object here -- the result of a previous call to this function --
+and we will sample some starting points from the final portion
+of the chains.}
 
 \item{n_chains}{Number of chains to run.  The default is to run a
 single chain, but you will likely want to run more.}

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -45,7 +45,10 @@ sampling.  If not given, we sample from the model (or its
 prior).  Alternatively, you can provide an \code{monty_samples}
 object here -- the result of a previous call to this function --
 and we will sample some starting points from the final portion
-of the chains.}
+of the chains (the exact details here are subject to change, but
+we'll sample from the last 20 points or 5\% of the chain, which
+ever smaller, with replacement, pooled across all chains in the
+previous sample).}
 
 \item{n_chains}{Number of chains to run.  The default is to run a
 single chain, but you will likely want to run more.}

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -441,3 +441,19 @@ test_that("can choose not to append when continuing samples", {
 
   expect_equal(res2b$pars, res1$pars[, 61:100, , drop = FALSE])
 })
+
+
+test_that("can use samples as initial conditions", {
+  set.seed(1)
+  m <- ex_sir_filter_posterior(n_particles = 20)
+  vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
+  sampler <- monty_sampler_random_walk(vcv = vcv)
+  initial <- c(0.2, 0.1)
+
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, 50, initial, n_chains = 2)
+  res2 <- monty_sample(m, sampler, 20, res1, n_chains = 3)
+
+  expect_equal(dim(res1$pars), c(2, 20, 2))
+  expect_equal(dim(res2$pars), c(2, 20, 3))
+})

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -485,6 +485,6 @@ test_that("can use samples as initial conditions", {
   res1 <- monty_sample(m, sampler, 50, initial, n_chains = 2)
   res2 <- monty_sample(m, sampler, 20, res1, n_chains = 3)
 
-  expect_equal(dim(res1$pars), c(2, 20, 2))
+  expect_equal(dim(res1$pars), c(2, 50, 2))
   expect_equal(dim(res2$pars), c(2, 20, 3))
 })


### PR DESCRIPTION
This makes picking up after we left off much easier, and also allows the results of a single chain to be used to create starting points for the next chain.  A third way of continuing chains (after continue, continue with `append = FALSE`) but all 3 have their uses I think.