### PR TITLE
Allow multiple parameters to dsl models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.30
+Version: 0.2.31
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/combine.R
+++ b/R/combine.R
@@ -245,11 +245,29 @@ model_combine_gradient <- function(a, b, parameters, properties, call = NULL) {
   n_pars <- length(parameters)
   i_a <- match(a$parameters, parameters)
   i_b <- match(b$parameters, parameters)
-  function(x, ...) {
+
+  gradient_vector <- function(x, ...) {
     ret <- numeric(n_pars)
     ret[i_a] <- ret[i_a] + a$gradient(x[i_a], ...)
     ret[i_b] <- ret[i_b] + b$gradient(x[i_b], ...)
     ret
+  }
+
+  if (properties$allow_multiple_parameters) {
+    function(x, ...) {
+      if (is.matrix(x)) {
+        ret <- matrix(0, n_pars, ncol(x))
+        ret[i_a, ] <-
+          ret[i_a, , drop = FALSE] + a$gradient(x[i_a, , drop = FALSE], ...)
+        ret[i_b, ] <-
+          ret[i_b, , drop = FALSE] + b$gradient(x[i_b, , drop = FALSE], ...)
+        ret
+      } else {
+        gradient_vector(x, ...)
+      }
+    }
+  } else {
+    gradient_vector
   }
 }
 

--- a/R/model.R
+++ b/R/model.R
@@ -58,20 +58,19 @@ monty_model_properties <- function(has_gradient = NULL,
                                    is_stochastic = NULL,
                                    has_parameter_groups = NULL,
                                    has_observer = NULL,
-                                   allow_multiple_parameters = FALSE) {
+                                   allow_multiple_parameters = NULL) {
   assert_scalar_logical(has_gradient, allow_null = TRUE)
   assert_scalar_logical(has_direct_sample, allow_null = TRUE)
   assert_scalar_logical(is_stochastic, allow_null = TRUE)
   assert_scalar_logical(has_parameter_groups, allow_null = TRUE)
   assert_scalar_logical(has_observer, allow_null = TRUE)
-  assert_scalar_logical(allow_multiple_parameters)
+  assert_scalar_logical(allow_multiple_parameters, allow_null = TRUE)
 
   ret <- list(has_gradient = has_gradient,
               has_direct_sample = has_direct_sample,
               is_stochastic = is_stochastic,
               has_parameter_groups = has_parameter_groups,
               has_observer = has_observer,
-              ## TODO: I am not convinced on this name
               allow_multiple_parameters = allow_multiple_parameters)
   class(ret) <- "monty_model_properties"
   ret
@@ -207,6 +206,8 @@ monty_model <- function(model, properties = NULL) {
   properties$is_stochastic <- !is.null(rng_state$set)
   properties$has_parameter_groups <- !is.null(parameter_groups)
   properties$has_observer <- !is.null(observer)
+  properties$allow_multiple_parameters <-
+    properties$allow_multiple_parameters %||% FALSE
 
   ret <- list(model = model,
               parameters = parameters,
@@ -619,7 +620,8 @@ monty_model_properties_str <- function(properties) {
   c(if (properties$has_gradient) "can compute gradients",
     if (properties$has_direct_sample) "can be directly sampled from",
     if (properties$is_stochastic) "is stochastic",
-    if (properties$has_observer) "has an observer")
+    if (properties$has_observer) "has an observer",
+    if (properties$allow_multiple_parameters) "accepts multiple parameters")
 }
 
 

--- a/man/monty_model_properties.Rd
+++ b/man/monty_model_properties.Rd
@@ -10,7 +10,7 @@ monty_model_properties(
   is_stochastic = NULL,
   has_parameter_groups = NULL,
   has_observer = NULL,
-  allow_multiple_parameters = FALSE
+  allow_multiple_parameters = NULL
 )
 }
 \arguments{

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -290,7 +290,8 @@ test_that("can combine models that allow multiple parameters", {
 
 
 test_that("Don't allow multiple parameters where either model lacks support", {
-  m <- ex_sir_filter_likelihood()
+  m <- ex_simple_gamma1()
+  m$properties$allow_multiple_parameters <- FALSE
   p <- monty_dsl({
     beta ~ Gamma(shape = 1, rate = 1 / 0.5)
     gamma ~ Gamma(shape = 1, rate = 1 / 0.5)
@@ -300,10 +301,10 @@ test_that("Don't allow multiple parameters where either model lacks support", {
 
   properties <- monty_model_properties(allow_multiple_parameters = FALSE)
   expect_false(
-    monty_model_combine(m, p, properties)$allow_multiple_parmeters)
+    monty_model_combine(m, p, properties)$properties$allow_multiple_parameters)
   properties <- monty_model_properties(allow_multiple_parameters = NULL)
   expect_false(
-    monty_model_combine(m, p, properties)$allow_multiple_parmeters)
+    monty_model_combine(m, p, properties)$properties$allow_multiple_parameters)
   properties <- monty_model_properties(allow_multiple_parameters = TRUE)
   expect_error(
     monty_model_combine(m, p, properties),

--- a/tests/testthat/test-combine.R
+++ b/tests/testthat/test-combine.R
@@ -286,6 +286,16 @@ test_that("can combine models that allow multiple parameters", {
   expect_equal(
     m$density(x),
     m1$density(x[1, , drop = FALSE]) + m2$density(x))
+  expect_equal(
+    m$density(x[, 1]),
+    m1$density(x[1, 1]) + m2$density(x[, 1]))
+
+  expect_equal(
+    m$gradient(x),
+    rbind(m1$gradient(x[1, , drop = FALSE]), 0) + m2$gradient(x))
+  expect_equal(
+    m$gradient(x[, 1]),
+    c(m1$gradient(x[1, 1]), 0) + m2$gradient(x[, 1]))
 })
 
 

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -150,3 +150,15 @@ test_that("can use fixed data in dsl", {
   }, fixed = list(mu = 1, sd = 2))
   expect_equal(m$density(0), dnorm(0, 1, 2, log = TRUE))
 })
+
+
+test_that("can evaluate dsl model densities for multiple parameters", {
+  m <- monty_dsl({
+    a ~ Normal(0, 1)
+    b ~ Exponential(2)
+  })
+  expect_true(m$properties$allow_multiple_parameters)
+  x <- matrix(runif(10), 2, 5)
+  expect_equal(m$density(x),
+               dnorm(x[1, ], 0, 1, TRUE) + dexp(x[2, ], 2, TRUE))
+})

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -161,4 +161,27 @@ test_that("can evaluate dsl model densities for multiple parameters", {
   x <- matrix(runif(10), 2, 5)
   expect_equal(m$density(x),
                dnorm(x[1, ], 0, 1, TRUE) + dexp(x[2, ], 2, TRUE))
+  expect_equal(
+    m$gradient(x),
+    apply(x, 2, m$gradient))
+  expect_equal(
+    m$gradient(x[, 1, drop = FALSE]),
+    cbind(m$gradient(x[, 1])))
+})
+
+
+test_that("gradient calculation correct single-parameter model", {
+  m <- monty_dsl({
+    a ~ Normal(0, 1)
+  })
+  expect_true(m$properties$allow_multiple_parameters)
+  x <- matrix(runif(5), 1, 5)
+  expect_equal(m$density(x),
+               dnorm(x[1, ], 0, 1, TRUE))
+  expect_equal(
+    m$gradient(x),
+    rbind(apply(x, 2, m$gradient)))
+  expect_equal(
+    m$gradient(x[, 1, drop = FALSE]),
+    cbind(m$gradient(x[, 1])))
 })

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -7,7 +7,8 @@ test_that("can create a minimal model", {
                                       has_direct_sample = FALSE,
                                       is_stochastic = FALSE,
                                       has_observer = FALSE,
-                                      has_parameter_groups = FALSE))
+                                      has_parameter_groups = FALSE,
+                                      allow_multiple_parameters = FALSE))
   expect_equal(m$domain, rbind(a = c(-Inf, Inf)))
   expect_equal(m$parameters, "a")
   expect_equal(m$density(0), dnorm(0, log = TRUE))


### PR DESCRIPTION
Two somewhat related features:

* DSL models now support (crudely) handling multiple parameters (a matrix of parameters yielding a vector of densities)
* We can propagate the `allow_multiple_parameters` property when combining models