### PR TITLE
Don't use parens in uminus on prefix function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.2.38
+Version: 0.2.39
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -254,7 +254,7 @@ maths <- local({
       if (fn == "(") {
         return(.parentheses_except(x[[2]], except))
       }
-      pass <- grepl("^[a-z]", fn) ||
+      pass <- grepl("^[A-Za-z]", fn) ||
         (length(except) > 0 && fn %in% except) ||
         "unary_minus" %in% except && .is_unary_minus(x)
       if (pass) {

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -253,6 +253,14 @@ test_that("uminus on subtraction reverses arguments", {
 })
 
 
+test_that("uminus does not use parens with prefix functions", {
+  expect_identical(maths$uminus(quote(f(a, b))),
+                   quote(-f(a, b)))
+  expect_identical(maths$uminus(quote(Fn(a, b))),
+                   quote(-Fn(a, b)))
+})
+
+
 test_that("times copes with numeric edge cases", {
   expect_identical(maths$times(3, 5), 15)
   expect_identical(maths$times(1, quote(a)), quote(a))


### PR DESCRIPTION
Spotted doing odin work, small PR there to fix effects of this too (https://github.com/mrc-ide/odin2/pull/106)