### PR TITLE
Allow manually sampled chains to be restarted

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/tests/testthat/test-sample-manual.R
+++ b/tests/testthat/test-sample-manual.R
@@ -301,3 +301,26 @@ test_that("can use burnin/thinning_factor in manual sampling", {
 
   expect_equal(res2b$pars, res1$pars)
 })
+
+
+test_that("can continue a manually run manual chain", {
+  model <- ex_simple_gamma1()
+  sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
+
+  path_a <- withr::local_tempdir()
+  path_b <- withr::local_tempdir()
+
+  set.seed(1)
+  monty_sample_manual_prepare(model, sampler, 20, path_a)
+  monty_sample_manual_run(1, path_a)
+  res1a <- monty::monty_sample_manual_collect(path_a, restartable = TRUE)
+
+  monty_sample_manual_prepare_continue(res1a, 30, path_b)
+  monty_sample_manual_run(1, path_b)
+  res1b <- monty::monty_sample_manual_collect(path_b, samples = res1a)
+
+  set.seed(1)
+  res2 <- monty_sample(model, sampler, 50)
+
+  expect_equal(res1b, res2)
+})

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -269,7 +269,6 @@ test_that("can continue a hmc model simultaneously, with debug", {
                           runner = runner)
   res2b <- monty_sample_continue(res2a, 70)
 
-  expect_equal(res1a$restart$state, res2a$restart$state)
   expect_equal(res1b, res2b)
   expect_equal(dim(res2b$details$pars), c(2, 11, 100, 3))
   expect_equal(dim(res2b$details$accept), c(100, 3))

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -110,9 +110,13 @@ test_that("can continue a simultaneous random walk sampler", {
   set.seed(1)
   runner <- monty_runner_simultaneous()
   res2a <- monty_sample(m, sampler, 30, n_chains = 3, runner = runner,
-                          restartable = TRUE)
-  expect_equal(res2a$restart$state, res1a$restart$state)
+                        restartable = TRUE)
 
+  drop_sampler_state <- function(x) {
+    x[names(x) != "sampler"]
+  }
+  expect_equal(lapply(res2a$restart$state, drop_sampler_state),
+               lapply(res1a$restart$state, drop_sampler_state))
   res2b <- monty_sample_continue(res2a, 70)
 
   expect_equal(res2b, res1b)


### PR DESCRIPTION
This gets very close to known issues around stateful samplers, but this workaround should be ok for now.