### PR TITLE
Support for differentiation through arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.22
+Version: 0.3.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -288,7 +288,7 @@ maths <- local({
         fn == "[" ||
         (length(except) > 0 && fn %in% except) ||
         "unary_minus" %in% except && .is_unary_minus(x)
-      if (pass) {
+      if (fn != "if" && pass) {
         return(x)
       }
       call("(", x)

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -147,7 +147,7 @@ derivative <- list(
   `[` = function(expr, name) {
     target <- as.character(expr[[2]])
     if (target != name) {
-      return(name)
+      return(0)
     }
     index <- as.list(expr[-(1:2)])
 

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -164,7 +164,7 @@ derivative <- list(
     }
 
     ## Have to resort to some actual calculation here, sadly:
-    call("if", fold("&&", i[!j]), 1, 0)
+    call("if", maths$fold("&&", i[!j]), 1, 0)
    },
   exp = function(expr, name) {
     a <- maths$rewrite(expr[[2]])

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -272,9 +272,7 @@ derivative <- list(
     if (is.symbol(target)) {
       return(if (as.character(target) == name) 1 else 0)
     }
-    if (!rlang::is_call(target, "[")) {
-      stop("Unsupported input to 'sum'")
-    }
+    stopifnot(rlang::is_call(target, "["))
 
     index <- as.list(target[-(1:2)])
     target <- target[[2]]

--- a/R/dsl-differentiate-expr.R
+++ b/R/dsl-differentiate-expr.R
@@ -144,6 +144,14 @@ derivative <- list(
   `(` = function(expr, name) {
     differentiate(expr[[2]], name)
   },
+  `[` = function(expr, name) {
+    res <- differentiate(expr[[2]], name)
+    if (is.numeric(res)) {
+      res
+    } else {
+      stop("Implement this - array access")
+    }
+  },
   exp = function(expr, name) {
     a <- maths$rewrite(expr[[2]])
     maths$times(differentiate(a, name), call("exp", a))
@@ -244,6 +252,14 @@ derivative <- list(
     b <- differentiate(call("lfactorial", k), name)
     c <- differentiate(call("lfactorial", maths$minus(n, k)), name)
     maths$minus(maths$minus(a, b), c)
+  },
+  sum = function(expr, name) {
+    target <- expr[[2]]
+    if (is.symbol(target)) {
+      return(if (as.character(target) == name) 1 else 0)
+    } else {
+      stop("Indexed sum not yet supported")
+    }
   }
 )
 

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -455,11 +455,27 @@ test_that("can diferentiate basic trig functions", {
 
 test_that("differentiate expressions with arrays", {
   expect_equal(differentiate(quote(x[i] + y[i]), "x"), 1)
-  expect_equal(differentiate(quote(x[i] + y[i]), "z"), 0
+  expect_equal(differentiate(quote(x[i] + y[i]), "z"), 0)
+  expect_equal(differentiate(quote(x[i]^2), "x"), quote(2 * x[i]))
+
+  expect_equal(differentiate(quote((x[i] - x[i + 1])^2), "x"),
+               quote(2 * (x[i] - x[1 + i])))
+  expect_equal(differentiate(quote(x[i] - x[i + 1]), "x"), 1)
 })
 
 
 test_that("differentiate expressions with arrays", {
   expect_equal(differentiate(quote(sum(x)), "x"), 1)
   expect_equal(differentiate(quote(sum(x)), "y"), 0)
+})
+
+
+test_that("test sameness", {
+  expect_true(is_same(1, 1))
+  expect_false(is_same(1, 0))
+  expect_true(is_same(quote(i), quote(i)))
+  expect_true(is_same(quote(j), quote(j)))
+  expect_equal(is_same(quote(i), quote(j)), quote(i == j))
+  expect_equal(is_same(quote(i), quote(2)), quote(i == 2))
+  expect_false(is_same(quote(i), quote(i + 1)))
 })

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -473,11 +473,36 @@ test_that("differentiate expressions with arrays", {
 
 
 test_that("test sameness", {
-  expect_true(is_same(1, 1))
-  expect_false(is_same(1, 0))
-  expect_true(is_same(quote(i), quote(i)))
-  expect_true(is_same(quote(j), quote(j)))
-  expect_equal(is_same(quote(i), quote(j)), quote(i == j))
-  expect_equal(is_same(quote(i), quote(2)), quote(i == 2))
-  expect_false(is_same(quote(i), quote(i + 1)))
+  expect_true(maths$is_same(1, 1))
+  expect_false(maths$is_same(1, 0))
+  expect_true(maths$is_same(quote(i), quote(i)))
+  expect_true(maths$is_same(quote(j), quote(j)))
+  expect_equal(maths$is_same(quote(i), quote(j)), quote(i == j))
+  expect_equal(maths$is_same(quote(i), quote(2)), quote(i == 2))
+  expect_false(maths$is_same(quote(i), quote(i + 1)))
+})
+
+
+test_that("decompose an expression into sum of parts", {
+  expect_equal(maths$as_sum_of_parts(1), list(1))
+  expect_equal(maths$as_sum_of_parts(quote(x)), list(quote(x)))
+  expect_equal(maths$as_sum_of_parts(quote(x + y)), list(quote(x), quote(y)))
+  expect_equal(maths$as_sum_of_parts(quote(x + y + z)),
+               list(quote(x), quote(y), quote(z)))
+  expect_equal(maths$as_sum_of_parts(quote(x + 2 * y + z)),
+               list(quote(x), quote(2 * y), quote(z)))
+  expect_equal(maths$as_sum_of_parts(quote(x - y)), list(quote(x), quote(-y)))
+  expect_equal(maths$as_sum_of_parts(quote(x - y - z)),
+               list(quote(x), quote(-y), quote(-z)))
+})
+
+
+## Lots that this does not cover yet, it's limited to support what
+## tends to happen in odin index calculations which are necessarily
+## simple
+test_that("factorise an expression", {
+  expect_equal(maths$factorise(quote(1)), quote(1))
+  expect_equal(maths$factorise(quote(a)), quote(a))
+  expect_equal(maths$factorise(quote(a + a)), quote(2 * a))
+  expect_equal(maths$factorise(quote(1 + 2)), quote(3))
 })

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -461,6 +461,9 @@ test_that("differentiate expressions with arrays", {
   expect_equal(differentiate(quote((x[i] - x[i + 1])^2), "x"),
                quote(2 * (x[i] - x[1 + i])))
   expect_equal(differentiate(quote(x[i] - x[i + 1]), "x"), 1)
+
+  expect_equal(differentiate(quote(3 * (x[2] - x[i])), "x"),
+               quote(3 * ((if (2 == i) 1 else 0) - 1)))
 })
 
 

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -454,22 +454,21 @@ test_that("can diferentiate basic trig functions", {
 
 
 test_that("differentiate expressions with arrays", {
-  expect_equal(differentiate(quote(x[i] + y[i]), "x"), 1)
-  expect_equal(differentiate(quote(x[i] + y[i]), "z"), 0)
-  expect_equal(differentiate(quote(x[i]^2), "x"), quote(2 * x[i]))
+  expect_identical(differentiate(quote(x[i] + y[i]), "x"), 1)
+  expect_identical(differentiate(quote(x[i] + y[i]), "z"), 0)
+  expect_identical(differentiate(quote(x[i]^2), "x"), quote(2 * x[i]))
 
-  expect_equal(differentiate(quote((x[i] - x[i + 1])^2), "x"),
-               quote(2 * (x[i] - x[1 + i])))
-  expect_equal(differentiate(quote(x[i] - x[i + 1]), "x"), 1)
-
-  expect_equal(differentiate(quote(3 * (x[2] - x[i])), "x"),
-               quote(3 * ((if (2 == i) 1 else 0) - 1)))
+  expect_identical(differentiate(quote((x[i] - x[i + 1])^2), "x"),
+                   quote(2 * (x[i] - x[1 + i])))
+  expect_identical(differentiate(quote(x[i] - x[i + 1]), "x"), 1)
+  expect_identical(differentiate(quote(3 * (x[i] - x[2])), "x"),
+                   quote(3 * (1 - (if (2 == i) 1 else 0))))
 })
 
 
 test_that("differentiate expressions with arrays", {
-  expect_equal(differentiate(quote(sum(x)), "x"), 1)
-  expect_equal(differentiate(quote(sum(x)), "y"), 0)
+  expect_identical(differentiate(quote(sum(x)), "x"), 1)
+  expect_identical(differentiate(quote(sum(x)), "y"), 0)
 })
 
 

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -451,3 +451,15 @@ test_that("can diferentiate basic trig functions", {
     differentiate(quote(tan(x)), "x"),
     quote(1 / cos(x)^2))
 })
+
+
+test_that("differentiate expressions with arrays", {
+  expect_equal(differentiate(quote(x[i] + y[i]), "x"), 1)
+  expect_equal(differentiate(quote(x[i] + y[i]), "z"), 0
+})
+
+
+test_that("differentiate expressions with arrays", {
+  expect_equal(differentiate(quote(sum(x)), "x"), 1)
+  expect_equal(differentiate(quote(sum(x)), "y"), 0)
+})

--- a/tests/testthat/test-dsl-differentiation.R
+++ b/tests/testthat/test-dsl-differentiation.R
@@ -463,12 +463,28 @@ test_that("differentiate expressions with arrays", {
   expect_identical(differentiate(quote(x[i] - x[i + 1]), "x"), 1)
   expect_identical(differentiate(quote(3 * (x[i] - x[2])), "x"),
                    quote(3 * (1 - (if (2 == i) 1 else 0))))
+
+  expect_identical(differentiate(quote(x[i] + x[j]), "x"),
+                   quote(1 + if (j == i) 1 else 0))
 })
 
 
-test_that("differentiate expressions with arrays", {
+test_that("differentiate complete sums with arrays", {
   expect_identical(differentiate(quote(sum(x)), "x"), 1)
   expect_identical(differentiate(quote(sum(x)), "y"), 0)
+})
+
+
+test_that("differentiate partial sums with arrays", {
+  expect_equal(differentiate(quote(sum(x[i, ])), "x"), 1)
+  expect_equal(differentiate(quote(sum(x[, i])), "x"),
+               quote(if (i == j) 1 else 0))
+  expect_equal(differentiate(quote(sum(x[i, , 3])), "x"),
+               quote(if (3 == k) 1 else 0))
+  expect_equal(differentiate(quote(sum(x[i, , a:b])), "x"),
+               quote(if (k >= a && k <= b) 1 else 0))
+  expect_equal(differentiate(quote(sum(x[, i, a:b])), "x"),
+               quote(if (i == j && k >= a && k <= b) 1 else 0))
 })
 
 


### PR DESCRIPTION
Some duplication of code from odin here, I've moved that within `maths` so that we can reuse it easily in odin.  Tests have been copied over too.

This PR includes support for differentiating array expressions.  These are quite hard to think about.

When we talk about differentiating with respect to `x` where `x` is an array, we seek to create an object with the same dimensions as `x`.  So if `x` is a vector then `d/dx(expr)` is a vector with the derivatives of `(x[1], x[2], ..., x[n])`.  Similarly if `x` is a matrix then `d/dx(expr)` is a matrix where element `(i, j)` is the derivative of `expr` with respect to `x[i, j]` and so on.

Array indexing is therefore pretty easy.  The derivative with respect to `x[...]` is 1 if we have a derivative of `x` at *exactly the same index* and 0 otherwise.  In many expressions we'll have `f(x[i])` on the rhs in which case we end up with `f'(x[i])` on the way out.

Things are harder if we have other indices within the expression:

```
> differentiate(quote(x[2]), "x")
if (2 == i) 1 else 0
```

this makes sense when we see the overall loop:

```
for (size_t i = 1 i <= n; ++i) {
  ... x[2] ...
}
```

so here the derivative of this expression is 1 where `i` is 2 and 0 otherwise.

For sums, the same logic applies: if we have the sum over the whole array `x` the derivative of this with respect to `x[i, j, ...]` is an array of 1 everywhere:

```
differentiate(quote(sum(x)), "x")
```

(it's useful to think of this within some loop driven by the indices on the lhs of odin, perhaps?).  This is because each element `x[...]` appears exactly once in the sum.

Partial sums are much nastier to think about but the solution here follows from the logic above: check that we include `x[...]` in the sum and return 1 if we do, 0 otherwise.

Do to this we check:

* are we summing over `x`
* can we see that our `x` is excluded (that is the same position in `x` is never consumed)
* generate a series of expressions for all remaining indices and `&&` them together, return `1` if they are all `TRUE`

Some examples:

```
> differentiate(quote(sum(x[i, ])), "x")
[1] 1
> differentiate(quote(sum(x[j, ])), "x")
if (j == i) 1 else 0
> differentiate(quote(sum(x[j, , a:b])), "x")
if (j == i && k >= a && k <= b) 1 else 0
```

