### PR TITLE
Fix restarting restarted chains, run manually

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.22
+Version: 0.3.23
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -193,7 +193,17 @@ monty_sample_manual_collect <- function(path, samples = NULL,
 
   prev <- sample_manual_collect_check_samples(inputs, samples, append)
 
-  observer <- inputs$model$observer
+  if (is.null(inputs$restart)) {
+    model <- inputs$model
+    sampler <- inputs$sampler
+    thinning_factor <- inputs$steps$thinning_factor
+  } else {
+    model <- inputs$restart$model
+    sampler <- inputs$restart$sampler
+    thinning_factor <- inputs$restart$thinning_factor
+  }
+
+  observer <- model$observer
   res <- lapply(path$results, readRDS)
   samples <- combine_chains(res, observer)
   if (!is.null(prev)) {
@@ -201,8 +211,9 @@ monty_sample_manual_collect <- function(path, samples = NULL,
   }
 
   if (restartable) {
-    samples$restart <- restart_data(res, inputs$model, inputs$sampler, NULL,
-                                    inputs$steps$thinning_factor)
+    runner <- NULL
+    samples$restart <- restart_data(res, model, sampler, runner,
+                                    thinning_factor)
   }
   samples
 }


### PR DESCRIPTION
Reported by @thomrawson, see "odin etc" Teams channel.

This PR fixes data saved as part of a restart when running chains manually; we were incorrectly saving the model and sampler.  A test is added which compares against the non-manual version