### PR TITLE
fix domain issue for truncated normal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.24
+Version: 0.3.25
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dsl-distributions.R
+++ b/R/dsl-distributions.R
@@ -239,7 +239,7 @@ distr_truncated_normal <- distribution(
   expr = list(
     mean = NULL,
     density = NULL),
-  domain = function(min, max) {
+  domain = function(mean, sd, min, max) {
     c(if (is.na(min)) -Inf else min, if (is.na(max)) Inf else max)
   },
   cpp = list(density = "truncated_normal",


### PR DESCRIPTION
Using `TruncatedNormal` in the DSL was throwing an error e.g.
```
m <- monty::monty_dsl({
    X ~ TruncatedNormal(mean = 5, sd = 1, min = 0, max = Inf)
},
gradient = FALSE)
```
resulted in
```
Error in (function (min, max)  : unused arguments (0, Inf)
```

This was because the domain function for `TruncatedNormal` had parameters `min, max` when of course it needed `mean, sd, min, max`!