### PR TITLE
Better behaviour of packers, model functions and multiple parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.26
+Version: 0.3.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/packer.R
+++ b/R/packer.R
@@ -206,6 +206,8 @@
 ##'   will be provided once the interface settles, but this is for
 ##'   advanced use only!
 ##'
+##' * `inputs`: inputs that could be used to reconstitute this packer.
+##'
 ##' @export
 ##'
 ##' @examples
@@ -393,11 +395,14 @@ monty_packer <- function(scalar = NULL, array = NULL, fixed = NULL,
     list(index = index, packer = packer)
   }
 
+  inputs <- list(array = shape, fixed = fixed, process = process)
+
   ret <- list(names = function() nms,
               unpack = unpack,
               pack = pack,
               index = function() idx,
-              subset = subset)
+              subset = subset,
+              inputs = function() inputs)
   class(ret) <- "monty_packer"
   ret
 }

--- a/man/monty_model_function.Rd
+++ b/man/monty_model_function.Rd
@@ -28,7 +28,8 @@ to \code{monty_packer} instead).}
 \item{allow_multiple_parameters}{Logical, indicating if passing in
 vectors for all parameters will return a vector of densities.
 This is \code{FALSE} by default because we cannot determine this
-automatically.}
+automatically.  Be aware that R's recycling rules may mean that
+this will not always work as expected!}
 }
 \value{
 A \link{monty_model} object that computes log density with the

--- a/man/monty_packer.Rd
+++ b/man/monty_packer.Rd
@@ -60,6 +60,7 @@ unpacked.  This is of limited most use to most people.
 a packer to a packer for a subset of contents. Documentation
 will be provided once the interface settles, but this is for
 advanced use only!
+\item \code{inputs}: inputs that could be used to reconstitute this packer.
 }
 }
 \description{

--- a/tests/testthat/test-model-function.R
+++ b/tests/testthat/test-model-function.R
@@ -65,3 +65,45 @@ test_that("can compute vectorised densities", {
   expect_equal(m$density(cbind(c(0, 1, 2), c(3, 4, 5))),
                dnorm(c(0, 3), c(1, 4), c(2, 5), log = TRUE))
 })
+
+
+test_that("can cope with fixed parameters and multiple inputs", {
+  fn <- function(a, b, c) {
+    a + b + c
+  }
+
+  m <- monty_model_function(fn, fixed = list(c = 10),
+                            allow_multiple_parameters = TRUE)
+  expect_equal(m$parameters, c("a", "b"))
+  expect_equal(m$density(c(1, 2)), 13)
+  expect_equal(m$density(matrix(1:6, 2)), c(13, 17, 21))
+})
+
+
+test_that("can undo fixed arguments to packer", {
+  fn <- function(a, b, c) {
+    a + b + c
+  }
+  p <- monty_packer(c("a", "b"), fixed = list(c = 10))
+  m <- monty_model_function(fn, packer = p,
+                            allow_multiple_parameters = TRUE)
+  expect_equal(m$parameters, c("a", "b"))
+  expect_equal(m$density(c(1, 2)), 13)
+  expect_equal(m$density(matrix(1:6, 2)), c(13, 17, 21))
+})
+
+
+test_that("can't use process in packer with multiple parameters", {
+  fn <- function(a, b, c) {
+    a + b + c
+  }
+  p <- monty_packer(c("a", "b"), process = function(x) list(c = 10))
+
+  m <- monty_model_function(fn, packer = p)
+  expect_equal(m$parameters, c("a", "b"))
+  expect_equal(m$density(c(1, 2)), 13)
+
+  expect_error(
+    monty_model_function(fn, packer = p, allow_multiple_parameters = TRUE),
+    "Can't use 'allow_multiple_parameters' with a packer")
+})

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -207,8 +207,12 @@ test_that("error if given the wrong size input to unpack", {
 test_that("can't used fixed with array unpacking", {
   p <- monty_packer(c("x", "y"), fixed = list(a = 10))
   expect_equal(p$unpack(1:2), list(x = 1, y = 2, a = 10))
+
+  p$unpack(matrix(1:6, 2))
+
+
   expect_error(
-    p$unpack(matrix(1:6, 2)),
+    ,
     "Can't unpack a matrix where the unpacker uses 'fixed'")
 })
 

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -204,19 +204,6 @@ test_that("error if given the wrong size input to unpack", {
 })
 
 
-test_that("can't used fixed with array unpacking", {
-  p <- monty_packer(c("x", "y"), fixed = list(a = 10))
-  expect_equal(p$unpack(1:2), list(x = 1, y = 2, a = 10))
-
-  p$unpack(matrix(1:6, 2))
-
-
-  expect_error(
-    ,
-    "Can't unpack a matrix where the unpacker uses 'fixed'")
-})
-
-
 test_that("can't used process with array unpacking", {
   p <- monty_packer(c("x", "y"), process = function(d) list(z = d$x + d$y))
   expect_equal(p$unpack(1:2), list(x = 1, y = 2, z = 3))


### PR DESCRIPTION
As seen in #137, our assumptions around how packers and multiple parameters don't hold here. We need to assume that the model function can cope with this, and so we intercept the packer before it would fail and inject the fixed parameters into the model function instead.