### PR TITLE
Safely restore models before running chain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.30
+Version: 0.3.31
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/runner.R
+++ b/R/runner.R
@@ -158,6 +158,7 @@ monty_run_chain_parallel <- function(chain_id, pars, model, sampler, steps,
 monty_run_chain <- function(chain_id, pars, model, sampler, steps,
                             progress, rng) {
   r_rng_state <- get_r_rng_state()
+  model$restore()
   chain_state <- sampler$initialise(pars, model, rng)
 
   if (!is.finite(chain_state$density)) {
@@ -189,6 +190,7 @@ monty_continue_chain <- function(chain_id, state, model, sampler, steps,
                                  progress) {
   r_rng_state <- get_r_rng_state()
   rng <- monty_rng_create(seed = state$rng)
+  model$restore()
   sampler$set_internal_state(state$sampler)
   if (model$properties$is_stochastic) {
     model$rng_state$set(state$model_rng)


### PR DESCRIPTION
Continuing the saga of safely coping with serialisation, this is a pretty small change in the end here.

* https://github.com/mrc-ide/monty/pull/115
* https://github.com/mrc-ide/dust2/pull/134
* https://github.com/mrc-ide/dust2/pull/138
* https://github.com/mrc-ide/dust2/pull/149

These currently work reasonably well, but fail in the case where a likelihood is used on the parent process, then serialised, then used; this is the problem as reported by Debbie.  The fix is very straightforward though and was introduced in #115 to be used (I think) in https://github.com/mrc-ide/dust2/pull/138 but never properly wired up it seems.

Hard to test programatically because the problem really only turns up in dust, but here's a simpler version of the problem as reported by Debbie using only dust2 and monty:

```r
pars <- list(beta = 0.1, gamma = 0.2, N = 1000, I0 = 10, exp_noise = 1e6)

data <- data.frame(time = c(4, 8, 12, 16), incidence = 1:4)

obj <- dust2::dust_unfilter_create(sir(), 0, data)
packer <- monty::monty_packer(
  c("beta", "gamma"),
  fixed = list(N = 1000, I0 = 10, exp_noise = 1e6))
prior <- monty::monty_dsl({
  beta ~ Exponential(mean = 0.5)
  gamma ~ Exponential(mean = 0.5)
})

sampler <- monty::monty_sampler_random_walk(diag(2) * c(0.02, 0.02))

# Run the likelihood first, works fine:
likelihood <- dust2::dust_likelihood_monty(obj, packer)
res <- monty::monty_sample(likelihood + prior, sampler, 10)

# Simulate save-and-load, then try again, fails with "pointer has
# already been serialised" error; this PR fixes this:
likelihood2 <- unserialize(serialize(likelihood, NULL))
res2 <- monty::monty_sample(likelihood2 + prior, sampler, 10)
```