### PR TITLE
Fix issues with truncated normal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.32
+Version: 0.3.33
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dsl-adjoint.R
+++ b/R/dsl-adjoint.R
@@ -2,26 +2,27 @@ dsl_parse_adjoint <- function(parameters, exprs, required, call = NULL) {
   if (isFALSE(required)) {
     return(NULL)
   }
-  exprs <- adjoint_rewrite_stochastic(parameters, exprs)
-  rlang::try_fetch(
-    adjoint_create(parameters, exprs),
-    monty_parse_error = function(e) {
-      if (is.null(required)) {
-        ## TODO: this might change as #52 is merged, to print slightly
-        ## more nicely.  At present we need one extra parent on this
-        ## than ideal because otherwise we don't get the contextual
-        ## information about the differentiation failure attached to
-        ## the warning.
-        cli::cli_warn(
-          c("Not creating a gradient function for this model",
-            i = paste("Pass 'gradient = FALSE' to disable creating the",
-                      "gradient function, which will disable this warning")),
-          parent = e)
-        NULL
-      } else {
-        rlang::zap() # not handling this, throw it anyway.
-      }
-    })
+  rlang::try_fetch({
+    exprs <- adjoint_rewrite_stochastic(parameters, exprs)
+    adjoint_create(parameters, exprs)
+  },
+  monty_parse_error = function(e) {
+    if (is.null(required)) {
+      ## TODO: this might change as #52 is merged, to print slightly
+      ## more nicely.  At present we need one extra parent on this
+      ## than ideal because otherwise we don't get the contextual
+      ## information about the differentiation failure attached to
+      ## the warning.
+      cli::cli_warn(
+        c("Not creating a gradient function for this model",
+          i = paste("Pass 'gradient = FALSE' to disable creating the",
+                    "gradient function, which will disable this warning")),
+        parent = e)
+      NULL
+    } else {
+      rlang::zap() # not handling this, throw it anyway.
+    }
+  })
 }
 
 
@@ -41,7 +42,7 @@ dsl_parse_adjoint <- function(parameters, exprs, required, call = NULL) {
 ## densities.
 ##
 ## > __density_a + __density_b + ... + __density_n
-adjoint_rewrite_stochastic <- function(parameters, exprs) {
+adjoint_rewrite_stochastic <- function(parameters, exprs, call = NULL) {
   prefix_density <- "__density"
   f <- function(eq) {
     if (eq$type == "assignment") {
@@ -49,8 +50,13 @@ adjoint_rewrite_stochastic <- function(parameters, exprs) {
     } else {
       args <- set_names(c(as.name(eq$name), eq$distribution$args),
                         names(formals(eq$distribution$density)))
-      rhs <- maths$rewrite(
-        substitute_(eq$distribution$expr$density, list2env(args)))
+      density_expr <- eq$distribution$expr$density_expr
+      if (is.null(density_expr)) {
+        dsl_parse_error(
+          "Density for '{eq$distribution$name}' not differentiable",
+          "E206", eq$expr, call)
+      }
+      rhs <- maths$rewrite(substitute_(density_expr, list2env(args)))
       name <- paste0(prefix_density, eq$name)
       list(type = "assignment",
            name = name,

--- a/R/dsl-adjoint.R
+++ b/R/dsl-adjoint.R
@@ -50,7 +50,7 @@ adjoint_rewrite_stochastic <- function(parameters, exprs, call = NULL) {
     } else {
       args <- set_names(c(as.name(eq$name), eq$distribution$args),
                         names(formals(eq$distribution$density)))
-      density_expr <- eq$distribution$expr$density_expr
+      density_expr <- eq$distribution$expr$density
       if (is.null(density_expr)) {
         dsl_parse_error(
           "Density for '{eq$distribution$name}' not differentiable",

--- a/inst/include/monty/random/density.hpp
+++ b/inst/include/monty/random/density.hpp
@@ -262,7 +262,7 @@ __host__ __device__ T beta(T x, T a, T b, bool log) {
 
 template <typename T>
 __host__ __device__ T truncated_normal(T x, T mu, T sd, T min, T max, bool log) {
-  const auto d = normal(x, mu, sd);
+  const auto d = normal(x, mu, sd, true);
 
   const auto z_min = 0.5 * (1 + std::erf(min / monty::math::sqrt(2)));
   const auto z_max = 0.5 * (1 + std::erf(max / monty::math::sqrt(2)));

--- a/inst/include/monty/random/density.hpp
+++ b/inst/include/monty/random/density.hpp
@@ -295,7 +295,7 @@ __host__ __device__ T weibull(T x, T shape, T scale, bool log) {
 
 template <typename T>
 __host__ __device__ T log_normal(T x, T mulog, T sdlog, bool log) {
-  const auto d = normal(monty::math::log(x), mulog, sdlog);
+  const auto d = normal(monty::math::log(x), mulog, sdlog, false);
   
   return log ? (d - monty::math::log(x)) : (monty::math::exp(d) / x);
 }

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -209,3 +209,14 @@ test_that("can apply a domain", {
   expect_equal(m$density(c(0, 1)), -Inf)
   expect_equal(m$density(c(1, 6)), -Inf)
 })
+
+
+test_that("can use truncated normal in dsl", {
+  expect_warning(
+    prior <- monty::monty_dsl({
+      beta ~ TruncatedNormal(mean = 0.2, sd = 0.1, min = 0.05, max = 0.5)
+    }),
+    "Not creating a gradient function for this model")
+  expect_s3_class(prior, "monty_model")
+  expect_false(prior$properties$has_gradient)
+})


### PR DESCRIPTION
Reported by Keith over Teams.

Two separate bugs here - one is that we don't have a `density` expression for `TruncatedNormal`; arguably we should because it's not that hard to write out really, but it's also useful to handle the case where the density is not present gracefully so this fix is still useful. We already have a "can't create adjoint model" path, which I've exploited here by raising an error that is caught by the adjoint construction, converting to a warning by default and an error where the user says that they really want a gradient.

See this in action with Keith's original report code:

```
prior <- monty::monty_dsl({
  beta ~ TruncatedNormal(mean = 0.2, sd = 0.1, min = 0.05, max = 0.5)
})
```

and see what happens with the `gradient` argument to `monty_dsl`

The other error is (still!) untested, because we don't have a general test setup for density functions; I had not written the call to the normal density properly, forgetting the `log` argument.  I tested this with a standalone odin model based on Keith's original comment:

```r
odin2::odin({
  initial(x) <- 0
  update(x) <- 0
  beta <- data()
  beta ~ TruncatedNormal(mean=0.2, sd=0.1, min=0.05, max=0.5)
})
```

which now compiles