### PR TITLE
More relaxed binomial check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.3.33
+Version: 0.3.34
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/inst/include/monty/random/binomial.hpp
+++ b/inst/include/monty/random/binomial.hpp
@@ -198,7 +198,10 @@ real_type btrs(rng_state_type& rng_state, real_type n, real_type p) {
 template <typename real_type>
 __host__ __device__
 void binomial_validate(real_type n, real_type p) {
-  if (n < 0 || p < 0 || p > 1 || std::isnan(n) || std::isnan(p)) {
+  const bool err = n < 0 || p < 0 || p > 1 ||
+    (std::isnan(p) && n > 0) ||
+    (std::isnan(n) && p > 0);
+  if (err) {
     char buffer[256];
     snprintf(buffer, 256,
              "Invalid call to binomial with n = %.0f, p = %g, q = %g",

--- a/inst/include/monty/random/binomial.hpp
+++ b/inst/include/monty/random/binomial.hpp
@@ -223,7 +223,7 @@ __host__ real_type binomial_deterministic(real_type n, real_type p) {
     }
   }
   binomial_validate(n, p);
-  return n * p;
+  return n > 0 && p > 0 ? n * p : 0;
 }
 
 // NOTE: we return a real, not an int, as with deterministic mode this

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -168,6 +168,21 @@ test_that("Binomial random numbers prevent bad inputs", {
 })
 
 
+test_that("binomial edge cases in deterministic mode", {
+  skip_on_cran() # potentially system dependent
+  r <- monty_rng_create(deterministic = TRUE)
+  expect_equal(monty_random_binomial(0, 0, r), 0)
+  expect_error(
+    monty_random_binomial(1, NaN, r),
+    "Invalid call to binomial with n = 1, p = .+")
+  expect_error(
+    monty_random_binomial(NaN, 1, r),
+    "Invalid call to binomial with n = .+, p = 1")
+  expect_equal(monty_random_binomial(0, NaN, r), 0)
+  expect_equal(monty_random_binomial(NaN, 0, r), 0)
+})
+
+
 test_that("avoid integer overflow in binomial draws with very large n", {
   r <- monty_rng_create(seed = 1)
   n <- 2^33

--- a/tests/testthat/test-rng.R
+++ b/tests/testthat/test-rng.R
@@ -137,7 +137,7 @@ test_that("binomial numbers and their complement are the same (np large)", {
 test_that("Binomial random numbers prevent bad inputs", {
   skip_on_cran() # potentially system dependent
   r <- monty_rng_create(seed = 1)
-  monty_random_binomial(0, 0, r)
+  expect_equal(monty_random_binomial(0, 0, r), 0)
   expect_error(
     monty_random_binomial(1, -1, r),
     "Invalid call to binomial with n = 1, p = -1")
@@ -155,12 +155,16 @@ test_that("Binomial random numbers prevent bad inputs", {
   expect_error(
     monty_random_binomial(-1, 0.5, r),
     "Invalid call to binomial with n = -1, p = 0.5")
+  ## Prevent NaN values
   expect_error(
     monty_random_binomial(1, NaN, r),
     "Invalid call to binomial with n = 1, p = .+")
   expect_error(
     monty_random_binomial(NaN, 1, r),
     "Invalid call to binomial with n = .+, p = 1")
+  ## But not in the edge cases where the answer is known
+  expect_equal(monty_random_binomial(0, NaN, r), 0)
+  expect_equal(monty_random_binomial(NaN, 0, r), 0)
 })
 
 


### PR DESCRIPTION
As reported by Neil on Teams, this restores the short-cut path available on odin.dust, and is reasonable with the usual R-ish interpretations of missing data (changing the value of the `NA` will not change the answer).