### PR TITLE
Coherent handlng of sampler state

### DIFF
--- a/R/arrays.R
+++ b/R/arrays.R
@@ -29,7 +29,23 @@ array_bind <- function(..., arrays = list(...), on = NULL,
         "Invalid value for 'before' ({before}), must be in [1, {r}]",
         arg = "before", call = call)
     }
-  } else if (is.null(on)) {
+  } else if (!is.null(on)) {
+    ## Allow people to write on = n to bind as a new dimension 'n'
+    ## just after the max extent, or on = 0 to bind at the min extent.
+    ## This will reduce some logic around aming arguments and allow
+    ## 'on' to be used for anything.
+    if (on == r + 1) {
+      after <- r
+      on <- NULL
+    } else if (on == 0) {
+      before <- 1
+      on <- NULL
+    } else if (on < 1 || on > r) {
+      cli::cli_abort(
+        "Invalid value for 'on' ({on}), must be in [0, {r + 1}]",
+        arg = "on", call = call)
+    }
+  } else {
     on <- r
   }
 
@@ -206,4 +222,21 @@ check_ranks_same <- function(arrays, message = NULL, call = call) {
   }
   r <- r[[1]]
   matrix(unlist(d), r)
+}
+
+
+array_select_last <- function(x, i, scalar = TRUE) {
+  if (scalar && is.list(x) && length(i) == 1 && length(dim2(x)) < 2) {
+    return(x[[i]])
+  }
+  r <- length(dim2(x))
+  if (r == 1) {
+    x[i]
+  } else if (r == 2) {
+    x[, i, drop = FALSE]
+  } else if (r == 3) {
+    x[, , i, drop = FALSE]
+  } else {
+    stop("unsupported access")
+  }
 }

--- a/R/arrays.R
+++ b/R/arrays.R
@@ -100,6 +100,10 @@ array_bind <- function(..., arrays = list(...), on = NULL,
     dimnames(ret) <- dn
   }
 
+  if (length(dim(ret)) == 1) {
+    dim(ret) <- NULL
+  }
+
   ret
 }
 

--- a/R/runner-callr.R
+++ b/R/runner-callr.R
@@ -117,10 +117,10 @@ monty_runner_callr <- function(n_workers, progress = NULL) {
     restart <- list(state = state,
                     model = model,
                     sampler = sampler)
-    n_chains <- length(state)
+    n_chains <- length(state$rng)
     path <- tempfile()
     monty_sample_manual_prepare_continue(
-      list(restart = restart), steps, path, "nothing")
+      list(state = state, restart = restart), steps, path, "nothing")
     loop(path, n_workers, n_chains, steps, progress)
   }
 

--- a/R/runner.R
+++ b/R/runner.R
@@ -132,8 +132,8 @@ monty_runner_parallel <- function(n_workers) {
                  sampler = sampler,
                  steps = steps,
                  progress = progress_bar_none()$update)
-    stop("FIXME")
     parallel::clusterApply(
+      cl,
       seq_len(n_chains),
       monty_continue_chain,
       state, model, sampler, steps, progress_bar_none()$update)

--- a/R/runner.R
+++ b/R/runner.R
@@ -216,18 +216,18 @@ monty_continue_chain <- function(chain_id, state, model, sampler, steps,
     model$rng_state$set(state$model_rng[[chain_id]])
   }
 
-  ## This is all quite easy because this is the last dimension.
   state_chain <- lapply(state$chain, array_select_last, chain_id)
+  state_chain$pars <- as.vector(state_chain$pars)
 
   if (is_v2_sampler(sampler)) {
-    sampler_state <- sampler$state$restore(
+    state_sampler <- sampler$state$restore(
       chain_id, state_chain, state$sampler, sampler$control, model)
   } else {
     sampler$set_internal_state(state$sampler)
-    sampler_state <- NULL
+    state_sampler <- NULL
   }
 
-  monty_run_chain2(chain_id, state_chain, sampler_state, model, sampler,
+  monty_run_chain2(chain_id, state_chain, state_sampler, model, sampler,
                    steps, progress, rng, r_rng_state)
 }
 

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -310,11 +310,9 @@ sample_manual_info_chain <- function(complete) {
 ##' @inherit monty_sample_manual_prepare return
 monty_sample_manual_prepare_continue <- function(samples, n_steps, path,
                                                  save_samples = "hash") {
-  ## I am not terribly happy wih the function name here, something for
-  ## the review?
-  ##
-  ## also not happy with save_samples = "nothing"
   restart <- samples$restart
+  state <- samples$state
+  n_chains <- length(samples$state$rng)
   samples <- sample_manual_prepare_check_samples(samples, save_samples)
 
   steps <- monty_sample_steps(n_steps,
@@ -322,7 +320,8 @@ monty_sample_manual_prepare_continue <- function(samples, n_steps, path,
                               thinning_factor = restart$thinning_factor)
 
   dat <- list(restart = restart,
-              n_chains = length(restart$state),
+              state = state,
+              n_chains = n_chains,
               steps = steps,
               samples = samples)
   sample_manual_path_create(path, dat)

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -138,11 +138,11 @@ monty_sample_manual_run <- function(chain_id, path, progress = NULL) {
   with_progress_fail_on_error(
     pb,
     if (is_continue) {
-      state <- restart$state
+      state <- inputs$state
       model <- restart$model
       sampler <- restart$sampler
-      res <- monty_continue_chain(chain_id, state[[chain_id]], model, sampler,
-                                  steps, pb$update)
+      res <- monty_continue_chain(chain_id, state, model, sampler, steps,
+                                  pb$update)
     } else {
       pars <- inputs$pars
       model <- inputs$model
@@ -205,15 +205,18 @@ monty_sample_manual_collect <- function(path, samples = NULL,
 
   observer <- model$observer
   res <- lapply(path$results, readRDS)
-  samples <- combine_chains(res, observer)
+  samples <- combine_chains(res, sampler, observer, restartable)
   if (!is.null(prev)) {
-    samples <- append_chains(prev, samples, observer)
+    samples <- append_chains(prev, samples, sampler, observer)
   }
 
   if (restartable) {
     runner <- NULL
-    samples$restart <- restart_data(res, model, sampler, runner,
-                                    thinning_factor)
+    samples$restart <- list(model = model,
+                            sampler = sampler,
+                            runner = NULL,
+                            ## TODO: rethink this; I think it becomes control?
+                            thinning_factor = thinning_factor)
   }
   samples
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -203,6 +203,14 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
     samples <- samples_new
   }
 
+  if (restartable) {
+    samples$restart <- list(model = model,
+                            sampler = sampler,
+                            runner = runner,
+                            ## TODO: rethink this; I think it becomes control?
+                            thinning_factor = thinning_factor)
+  }
+
   samples
 }
 
@@ -395,6 +403,7 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
                   density = array_bind(prev$density, curr$density, on = 1),
                   initial = prev$initial,
                   details = curr$details,
+                  state = curr$state,
                   observations = observations)
   class(samples) <- "monty_samples"
   samples
@@ -540,8 +549,8 @@ monty_samples <- function(pars, density, initial, details, observations,
                   density = density,
                   initial = initial,
                   details = details,
-                  observations = observations,
-                  state = state)
+                  state = state,
+                  observations = observations)
   class(samples) <- "monty_samples"
   samples
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -377,7 +377,7 @@ combine_chains <- function(res, sampler, observer, include_state) {
   if (is.null(observer)) {
     observations <- NULL
   } else {
-    observations <- observer$combine(lapply(history, "[[", observations))
+    observations <- observer$combine(lapply(history, "[[", "observations"))
   }
 
   initial <- array_bind(arrays = lapply(res, "[[", "initial"), after = 1)
@@ -389,11 +389,15 @@ combine_chains <- function(res, sampler, observer, include_state) {
   details <- sampler$state$details(sampler_state)
 
   if (include_state) {
+    model_rng <- lapply(state, "[[", "model_rng")
+    if (all(vlapply(model_rng, is.null))) {
+      model_rng <- NULL
+    }
     state <- list(
       chain = combine_state_chain(lapply(state, "[[", "chain")),
       sampler = sampler_state,
       rng = lapply(state, "[[", "rng"),
-      model_rng = lapply(state, "[[", "model_rng"))
+      model_rng = model_rng)
   } else {
     state <- NULL
   }
@@ -544,10 +548,15 @@ tail_and_pool <- function(pars, p, n) {
 
 
 combine_state_chain <- function(state) {
+  observation <- lapply(state, "[[", "observation")
+  if (all(vlapply(observation, is.null))) {
+    observation <- NULL
+  }
+
   list(
     pars = array_bind(arrays = lapply(state, "[[", "pars"), after = Inf),
     density = vnapply(state, "[[", "density"),
-    observation = lapply(state, "[[", "observation"))
+    observation = observation)
 }
 
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -359,6 +359,15 @@ initial_parameters <- function(initial, model, rng, call = NULL) {
 
 
 combine_chains <- function(res, sampler, observer, include_state) {
+  ## If we used the simultaneous sampler, we've already constructed
+  ## something useful here.
+  if (inherits(res, "monty_samples")) {
+    if (!include_state) {
+      res["state"] <- list(NULL)
+    }
+    return(res)
+  }
+
   warn_if_used_r_rng(vlapply(res, "[[", "used_r_rng"))
 
   ## First, process the core history:

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -490,6 +490,14 @@ sampler_random_walk_adaptive_state_dump <- function(state) {
     arr <- array(ret$history_pars, c(n_pars, n_sets, n_steps))
     ret$history_pars <- aperm(arr, c(1, 3, 2))
   }
+
+  if (n_sets > 1) {
+    ret$scaling_history <- matrix(ret$scaling_history,
+                                  ncol = n_sets, byrow = TRUE)
+    ret$iteration <- rep(ret$iteration, n_sets)
+    ret$weight <- rep(ret$weight, n_sets)
+  }
+
   ret
 }
 
@@ -499,6 +507,10 @@ sampler_random_walk_adaptive_state_restore <- function(chain_id, state_chain,
                                                        model) {
   state <- lapply(state_sampler, array_select_last, chain_id)
   state$history_pars <- as.vector(state$history_pars)
+  if (length(chain_id) > 1) {
+    state$iteration <- state$iteration[[1]]
+    state$weight <- state$weight[[1]]
+  }
   list2env(state, parent = emptyenv())
 }
 

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -184,7 +184,10 @@ monty_sampler_adaptive <- function(initial_vcv,
                  control,
                  sampler_random_walk_adaptive_initialise,
                  sampler_random_walk_adaptive_step,
-                 details = sampler_random_walk_adaptive_details)
+                 sampler_random_walk_adaptive_state_dump,
+                 sampler_random_walk_adaptive_state_combine,
+                 sampler_random_walk_adaptive_state_restore,
+                 sampler_random_walk_adaptive_details)
 }
 
 
@@ -221,7 +224,7 @@ sampler_random_walk_adaptive_initialise <- function(state_chain, control,
   state$scaling <- rep(control$initial_scaling, n_sets)
   state$scaling_weight <- rep(control$initial_scaling_weight, n_sets)
 
-  state$history_pars <- NULL
+  state$history_pars <- numeric(0)
   state$scaling_history <- rep(control$initial_scaling, n_sets)
 
   state
@@ -264,40 +267,10 @@ sampler_random_walk_adaptive_step <- function(state_chain, state_sampler,
 }
 
 
-sampler_random_walk_adaptive_details <- function(state_chain, state_sampler,
-                                                 control, model) {
-  multiple_parameters <- length(dim2(state_chain$pars)) > 1
-  keep <- c("autocorrelation", "mean", "vcv", "weight",
-            "scaling_history", "scaling_weight")
-  ret <- set_names(lapply(keep, function(nm) state_sampler[[nm]]), keep)
-
-  if (multiple_parameters) {
-    ## There's an issue here where we need to break up our nice data
-    ## structure into something comparable with the individually run
-    ## chains.  We'll fix this by having explicit 'combine' and
-    ## 'append' support here, as we do in the observer, as it's the
-    ## same basic problem.  But for now, let's be consistent and break
-    ## it all apart.
-    n_pars <- nrow(state_chain$pars)
-    n_sets <- ncol(state_chain$pars)
-    ret$scaling_history <- matrix(ret$scaling_history, n_sets)
-    ret <- lapply(seq_len(n_sets), function(i) {
-      list(
-        autocorrelation = matrix(ret$autocorrelation[, , i], n_pars),
-        mean = ret$mean[, i],
-        vcv = matrix(ret$vcv[, , i], n_pars),
-        weight = ret$weight,
-        scaling_history = ret$scaling_history[i, ],
-        scaling_weight = ret$scaling_weight[i])
-    })
-  } else {
-    n_pars <- length(state_chain$pars)
-    ret$autocorrelation <- matrix(ret$autocorrelation, n_pars)
-    ret$mean <- as.vector(ret$mean)
-    ret$vcv <- matrix(ret$vcv, n_pars)
-  }
-
-  ret
+sampler_random_walk_adaptive_details <- function(state) {
+  ## Dropping these, as we had previously decided to -- we could
+  ## return them too but no real need.
+  state[setdiff(names(state), c("history_pars", "scaling"))]
 }
 
 
@@ -494,4 +467,69 @@ validate_forget_rate <- function(forget_rate, call = parent.frame()) {
       arg = "forget_rate", call = call)
   }
   as.integer(ret)
+}
+
+
+sampler_random_walk_adaptive_state_dump <- function(state) {
+  ret <- as.list(state, sorted = TRUE)
+
+  ## 'history_pars' is stored in a flat vector for easy accumulation,
+  ## but here we reshape to something actually useful.  A bit of work
+  ## in the simultaneous case to get the order <step> x <chain>, as we
+  ## accumulate in the other order (all chains for a given step) and
+  ## need to transpose here.  For the single case it's a unit
+  ## dimension so it doesn't really matter.
+  n_pars <- nrow(state$mean)
+  n_sets <- ncol(state$mean)
+  n_steps <- state$iteration
+  if (length(ret$history_pars) == 0) {
+    ret$history_pars <- array(0, c(n_pars, 0, n_sets))
+  } else if (n_sets == 1) {
+    ret$history_pars <- array(ret$history_pars, c(n_pars, n_steps, n_sets))
+  } else {
+    ret$history_pars <- aperm(ret$history_pars, c(n_pars, n_sets, n_steps),
+                              c(1, 3, 2))
+  }
+  ret
+}
+
+
+sampler_random_walk_adaptive_state_restore <- function(chain_id, state_chain,
+                                                       state_sampler, control,
+                                                       model) {
+  state <- lapply(state_sampler, array_select_last, chain_id)
+  state$history_pars <- as.vector(state$history_pars)
+  list2env(state, parent = emptyenv())
+}
+
+
+sampler_random_walk_adaptive_state_combine <- function(state) {
+  ## The dimension order is always <pars>, <step>, <chain> so when
+  ## combining results for single chain we have:
+  ##
+  ## autocorrelation: <pars> x <pars> x 1 -> <pars> x <pars> x <chain>
+  ## history_pars: <pars> x <step> x 1 -> <pars> x <step> x <chain>
+  ## iteration: 1 -> <chain>
+  ## mean: <pars> x 1 -> <pars> x <chain>
+  ## scaling: 1 -> <chain>
+  ## scaling_history: <step> -> <step> x <chain>
+  ## scaling_weight: 1 -> <chain>
+  ## vcv: <pars> x <pars> x 1 -> <pars> x <pars> x <chain>
+  ## weight: 1 -> <chain>
+  join <- function(name, ...) {
+    array_bind(arrays = lapply(state, "[[", name), ...)
+  }
+
+  ## We can probably express this purely in data, which might be
+  ## useful for eventual generalisation, though I think I now have
+  ## them all being simply "bind on the last element"
+  list(autocorrelation = join("autocorrelation", on = 3),
+       history_pars = join("history_pars", on = 3),
+       iteration = join("iteration", on = 1),
+       mean = join("mean", on = 2),
+       scaling = join("scaling_weight", on = 1),
+       scaling_history = join("scaling_history", on = 2),
+       scaling_weight = join("scaling_weight", on = 1),
+       vcv = join("vcv", on = 3),
+       weight = join("weight", on = 1))
 }

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -487,8 +487,8 @@ sampler_random_walk_adaptive_state_dump <- function(state) {
   } else if (n_sets == 1) {
     ret$history_pars <- array(ret$history_pars, c(n_pars, n_steps, n_sets))
   } else {
-    ret$history_pars <- aperm(ret$history_pars, c(n_pars, n_sets, n_steps),
-                              c(1, 3, 2))
+    arr <- array(ret$history_pars, c(n_pars, n_sets, n_steps))
+    ret$history_pars <- aperm(arr, c(1, 3, 2))
   }
   ret
 }
@@ -527,7 +527,7 @@ sampler_random_walk_adaptive_state_combine <- function(state) {
        history_pars = join("history_pars", on = 3),
        iteration = join("iteration", on = 1),
        mean = join("mean", on = 2),
-       scaling = join("scaling_weight", on = 1),
+       scaling = join("scaling", on = 1),
        scaling_history = join("scaling_history", on = 2),
        scaling_weight = join("scaling_weight", on = 1),
        vcv = join("vcv", on = 3),

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -39,9 +39,11 @@ monty_sampler_hmc <- function(epsilon = 0.015, n_integration_steps = 10,
                  control,
                  sampler_hmc_initialise,
                  sampler_hmc_step,
-                 sampler_hmc_dump,
-                 sampler_hmc_restore,
-                 sampler_hmc_details)
+                 sampler_hmc_state_dump,
+                 sampler_hmc_state_restore,
+                 sampler_hmc_state_combine,
+                 sampler_hmc_state_split,
+                 sampler_hmc_state_details)
 }
 
 
@@ -124,19 +126,34 @@ sampler_hmc_details <- function(state_chain, state_sampler, control, model) {
 }
 
 
-sampler_hmc_dump <- function(state_sampler) {
+sampler_hmc_state_dump <- function(state_sampler) {
   if (is.null(state_sampler$history)) {
     return(NULL)
   }
-  list(history = state_sampler$history$dump())
+  state_sampler$history$dump()
 }
 
 
-sampler_hmc_restore <- function(state_chain, state_sampler, control, model) {
+sampler_hmc_state_restore <- function(state_chain, state_sampler, control, model) {
   pars <- state_chain$pars
   list(transform = hmc_transform(model, pars),
        sample_momentum = hmc_momentum(control, model, pars),
        history = hmc_history_recorder(control, pars, state_sampler$history))
+}
+
+
+sampler_hmc_state_combine <- function(state) {
+  browser()
+}
+
+
+sampler_hmc_state_split <- function(state) {
+  browser()
+}
+
+
+sampler_hmc_state_details <- function(state, model) {
+  browser()
 }
 
 

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -63,6 +63,7 @@ monty_sampler_random_walk <- function(vcv, boundaries = "reflect",
                  sampler_random_walk_initialise,
                  sampler_random_walk_step,
                  sampler_random_walk_dump,
+                 sampler_random_walk_combine,
                  sampler_random_walk_restore)
 }
 
@@ -119,18 +120,26 @@ sampler_random_walk_step <- function(state_chain, state_sampler, control,
 }
 
 
-sampler_random_walk_dump <- function(state_sampler) {
-  if (is.null(state_sampler$rerun)) {
+sampler_random_walk_dump <- function(state) {
+  if (is.null(state$rerun)) {
     return(NULL)
   }
-  list(rerun_state = attr(state_sampler$rerun, "data"))$step
+  list(rerun_state = attr(state$rerun, "data"))$step
 }
 
 
-sampler_random_walk_restore <- function(state_chain, state_sampler, control,
+sampler_random_walk_combine <- function(state) {
+  if (all(vlapply(state, is.null))) {
+    return(NULL)
+  }
+  state[[1]]
+}
+
+
+sampler_random_walk_restore <- function(chain_id, state_chain,
+                                        state_sampler, control,
                                         model) {
   pars <- state_chain$pars
-  ## TODO: come up with a pattern for reusing things
   list(proposal = make_random_walk_proposal(control, model, pars),
        rerun = make_rerun(control, model, state_sampler$rerun_state))
 }

--- a/R/sampler.R
+++ b/R/sampler.R
@@ -217,16 +217,16 @@ monty_sampler2_state <- function(dump, restore, combine, details) {
   ret <- list(dump = dump,
               restore = restore,
               combine = combine,
-              details = details)
+              details = details %||% monty_sampler2_default_details)
   class(ret) <- "monty_sampler2_state"
   ret
 }
 
 
 
+## Most of this can probably come out
 monty_sampler2_state_empty <- function() {
   monty_sampler2_state(
-    function(...) NULL,
     function(...) NULL,
     function(...) NULL,
     function(...) NULL,

--- a/R/util.R
+++ b/R/util.R
@@ -224,3 +224,8 @@ last <- function(x) {
 is_testing <- function() {
   identical(Sys.getenv("TESTTHAT"), "true")
 }
+
+
+return_null <- function(...) {
+  NULL
+}

--- a/man/monty_sampler2.Rd
+++ b/man/monty_sampler2.Rd
@@ -11,8 +11,9 @@ monty_sampler2(
   initialise,
   step,
   state_dump = NULL,
+  state_combine = NULL,
   state_restore = NULL,
-  details = NULL
+  state_details = NULL
 )
 }
 \arguments{
@@ -66,10 +67,16 @@ reference.
 Return \code{state_chain}, updated after acceptance.}
 
 \item{state_dump}{Optionally, a function to prepare the chain
-state for serialisation.  If not given, we assume that
-\code{as.list()} is sufficient and use that (unless your state is
-\code{NULL}, in which case we use \code{identity}).  If provided then
-typically you will need to provide \code{state_restore}, too.}
+state for serialisation.  If not given, we assume that nothing
+needs to be saved and that your sampler can be restarted from
+just the state of the chain, the model and \code{control}.  If
+provided then typically you will need to provide
+\code{state_restore}, too.}
+
+\item{state_combine}{Optionally, a function to combine the output
+of several chains (a list, where each element has come from
+\code{state_dump}) into a single object that is consistent with what
+the simultaneous runner would have produced.}
 
 \item{state_restore}{Optionally, a function to take a dumped chain
 state and convert it back into an environment.  If not given, we
@@ -79,36 +86,30 @@ use that (unless your state is \code{NULL}, in which case we use
 provide \code{state_dump}, too.  The arguments here, if provided,
 must be
 \itemize{
+\item \code{chain_id}
 \item \code{state_chain}
 \item \code{state_sampler}
 \item \code{control}
 \item \code{model}
 }}
 
-\item{details}{Optionally, a function to tidy internal state to be
-saved at the end of the run.  If you provide this you almost
-certainly need to provide \code{state_dump} and \code{state_restore}.  The
-arguments here must be:
-\itemize{
-\item \code{state_chain}
-\item \code{state_sampler}
-\item \code{control}
-\item \code{model}
-}
-
-but we expect that only \code{state_sampler} will generally be
-needed.  Return whatever you fancy.}
+\item{state_details}{Optionally, a function to tidy internal state
+to be saved at the end of the run.  If you provide this you
+almost certainly need to provide \code{state_dump} and
+\code{state_restore}.  This takes the combined state as its only
+argument.}
 }
 \value{
 A \code{monty_sampler2} object
 }
 \description{
 A \code{monty_sampler2} object can be passed into \code{monty_sample} in
-order to draw samples from a distribution.  Samplers are stateful
-objects that can mutate the state of a markov chain and advance
-the MCMC one step.  Ordinarily users will not call this function,
-but authors of samplers will call it from the constructor of their
-sampler.
+order to draw samples from a distribution.  The primary role of a
+sampler is to advance the state of a Markov chain one step; in
+doing so they may mutate some internal state (outside the
+knowledge of the problem being advanced).  Ordinarily users will
+not call this function, but authors of samplers will call it from
+the constructor of their sampler.
 }
 \details{
 See \code{vignette("writing-samplers")} for an introduction to writing
@@ -121,3 +122,71 @@ sampler designer will construct this list and should take care not
 to include anything mutable (e.g. environments) or hard to
 serialise and transfer to another process here.
 }
+\section{Sampler state}{
+Your sampler can have internal state.  This is not needed for
+simple samplers; a random walk Metropolis-Hastings sampler does
+not need this for example as its state is entirely defined by the
+(\code{pars}, \code{density}) pair that forms the chain state.  Similarly,
+simple implemenations of HMC or Gibbs samplers would not need this
+functionality.  If you wish to record debug information, or if
+your sampler updates some internal state as it runs -- as our
+adaptive Metropolis-Hastings sampler does -- then you will need to
+configure your sampler to initialise, store, combine and restore
+this state.
+
+There are four state handling functions.  If you provide one, you
+probably will need to provide them all, though \code{details} can be
+omitted if you do not want to render out a user-facing summary of
+your sampler state at the end of a chain.
+\itemize{
+\item \code{state_dump}: this takes the sampler state (which is often an
+environment) and returns a list.  In most cases, this is for a
+single chain, but if your sampler is used with
+\code{\link[=monty_runner_simultaneous]{monty_runner_simultaneous()}} this will correspond to the state
+for a number of chains at once, in which case your dumped state
+should look like the output from combining chains.
+\item \code{state_combine}: this takes a list of sampler states, each of
+which was dumped with \code{state_dump} and combines them into a
+single state object.  You need to aim for the case where the
+output of this function is the same as running \code{state_dump}
+after running with \code{\link[=monty_runner_simultaneous]{monty_runner_simultaneous()}}.  Hopefully we
+can write some things to help with this, or at least example
+tests that will probably satisfy this.
+\item \code{state_restore}: this takes the output of \code{state_split} (or
+\code{state_combine} in the case of \code{\link[=monty_runner_simultaneous]{monty_runner_simultaneous()}})
+and prepares the state for use with the sampler.  This function
+takes arguments:
+\itemize{
+\item \code{chain_id}: one or more chain ids
+\item \code{state_chain}: the state of the chain(s) at the point of
+restoration
+\item \code{state_sampler}: the state from \code{state_combine}
+\item \code{control}: the sampler control
+\item \code{model}: the model
+}
+\item \code{state_details}: this takes the output of \code{state_combine} and
+returns a cleaned version of the state back to the user, as the
+\verb{$details} element of the final samples.  Use this to extract a
+fraction of the total state where only some should be
+user-visible.  You do not need to provide this, the default is
+to return nothing.
+}
+
+State initialisation is handled by \code{initialise}; however, a
+nontrivial return value from this function does not imply that
+your sampler needs to worry very much about state.  If you can
+entirely construct this from the current state of the chain and
+the control parameters, then no state management is required.
+However, a nontrivial return value from \code{initialise} requires a
+\code{state_restore} argument, even if \code{state_dump} is not present.
+
+The state manoeuvres may feel tedious, but it will form part of
+the core of how the Parallel Tempering algorithm works, where we
+need to be ablt to run multiple chains through a sampler at the
+same time.
+
+We will set things up soon so that if you do not provide these
+functions (but if you do provide state), then your sampler will
+work, but it will fail informatively when you try and continue it.
+}
+

--- a/tests/testthat/helper-monty.R
+++ b/tests/testthat/helper-monty.R
@@ -173,3 +173,9 @@ scrub_manual_info <- function(x) {
            x)
   x
 }
+
+
+drop_runner <- function(x) {
+  x$restart$runner <- NULL
+  x
+}

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -17,9 +17,9 @@ test_that("sampler return value contains history", {
   model <- ex_simple_gamma1()
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   res <- monty_sample(model, sampler, 100, 1)
-  ## TODO: what is in details?
-  expect_setequal(names(res),
-                  c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "state", "observations"))
   expect_equal(dim(res$pars), c(1, 100, 1))
   expect_equal(dimnames(res$pars), list("gamma", NULL, NULL))
   expect_equal(dim(res$density), c(100, 1))

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -6,13 +6,15 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0", {
                                     log_scaling_update = FALSE)
   res <- monty_sample(m, sampler, 1000)
 
-  expect_equal(names(res),
-               c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "observations", "state"))
 
   ## forget_rate = 0 so full chain should be included in VCV
   expect_equal(res$details$weight[[1]], 1000)
   pars <- t(array_drop(res$pars, 3))
   expect_equal(res$details$vcv[, , 1], cov(unname(pars)))
+  expect_null(res$state)
 })
 
 
@@ -23,8 +25,9 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0.1", {
   sampler <- monty_sampler_adaptive(initial_vcv = diag(c(0.01, 0.01)),
                                     forget_rate = 0.1)
   res <- monty_sample(m, sampler, 1000)
-  expect_equal(names(res),
-               c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "observations", "state"))
 
   ## forget_rate = 0.1 so VCV should exclude first 100 parameter sets
   expect_equal(res$details$weight[[1]], 900)
@@ -40,8 +43,9 @@ test_that("Empirical VCV correct using both forget_rate and forget_end", {
                                     forget_rate = 0.5,
                                     forget_end = 200)
   res <- monty_sample(m, sampler, 1000)
-  expect_equal(names(res),
-               c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "observations", "state"))
 
   ## forget_rate = 0.5 and forget_end = 200 so VCV should exclude first
   ## 100 parameter sets
@@ -59,8 +63,9 @@ test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
                                     forget_end = 100,
                                     adapt_end = 300)
   res <- monty_sample(m, sampler, 1000)
-  expect_equal(names(res),
-               c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "observations", "state"))
 
   ## forget_rate = 0.25, forget_end = 500 and adapt_end = 300 so VCV should
   ## only include parameter sets 26 to 300

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -10,9 +10,9 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0", {
                c("pars", "density", "initial", "details", "observations"))
 
   ## forget_rate = 0 so full chain should be included in VCV
-  expect_equal(res$details[[1]]$weight, 1000)
+  expect_equal(res$details$weight[[1]], 1000)
   pars <- t(array_drop(res$pars, 3))
-  expect_equal(res$details[[1]]$vcv, cov(pars), ignore_attr = TRUE)
+  expect_equal(res$details$vcv[, , 1], cov(unname(pars)))
 })
 
 
@@ -27,10 +27,9 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0.1", {
                c("pars", "density", "initial", "details", "observations"))
 
   ## forget_rate = 0.1 so VCV should exclude first 100 parameter sets
-  expect_equal(res$details[[1]]$weight, 900)
+  expect_equal(res$details$weight[[1]], 900)
   pars <- t(array_drop(res$pars, 3))
-  expect_equal(res$details[[1]]$vcv, cov(pars[101:1000, ]),
-               ignore_attr = TRUE)
+  expect_equal(res$details$vcv[, , 1], cov(unname(pars[101:1000, ])))
 })
 
 
@@ -46,10 +45,9 @@ test_that("Empirical VCV correct using both forget_rate and forget_end", {
 
   ## forget_rate = 0.5 and forget_end = 200 so VCV should exclude first
   ## 100 parameter sets
-  expect_equal(res$details[[1]]$weight, 900)
+  expect_equal(res$details$weight[[1]], 900)
   pars <- t(array_drop(res$pars, 3))
-  expect_equal(res$details[[1]]$vcv, cov(pars[101:1000, ]),
-               ignore_attr = TRUE)
+  expect_equal(res$details$vcv[, , 1], cov(unname(pars[101:1000, ])))
 })
 
 
@@ -66,10 +64,9 @@ test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
 
   ## forget_rate = 0.25, forget_end = 500 and adapt_end = 300 so VCV should
   ## only include parameter sets 26 to 300
-  expect_equal(res$details[[1]]$weight, 275)
+  expect_equal(res$details$weight[[1]], 275)
   pars <- t(array_drop(res$pars, 3))
-  expect_equal(res$details[[1]]$vcv, cov(pars[26:300, ]),
-               ignore_attr = TRUE)
+  expect_equal(res$details$vcv[, , 1], cov(unname(pars[26:300, ])))
 })
 
 

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -27,12 +27,12 @@ test_that("can output debug traces", {
 
   set.seed(1)
   sampler1 <- monty_sampler_hmc(epsilon = 0.1, n_integration_steps = 10)
-  res1 <- monty_sample(m, sampler1, 30)
+  res1 <- monty_sample(m, sampler1, 30, n_chains = 2)
 
   set.seed(1)
   sampler2 <- monty_sampler_hmc(epsilon = 0.1, n_integration_steps = 10,
                                   debug = TRUE)
-  res2 <- monty_sample(m, sampler2, 30)
+  res2 <- monty_sample(m, sampler2, 30, n_chains = 2)
 
   expect_null(res1$details)
   expect_length(res2$details, 1)

--- a/tests/testthat/test-sampler-hmc.R
+++ b/tests/testthat/test-sampler-hmc.R
@@ -35,16 +35,14 @@ test_that("can output debug traces", {
   res2 <- monty_sample(m, sampler2, 30, n_chains = 2)
 
   expect_null(res1$details)
-  expect_length(res2$details, 1)
-  expect_equal(names(res2$details[[1]]), c("pars", "accept"))
-  expect_equal(res2$details[[1]]$accept, rep(TRUE, 30))
+  expect_equal(names(res2$details), c("pars", "accept"))
+  expect_equal(res2$details$accept, matrix(TRUE, 30, 2))
 
-  pars <- array_drop(res2$pars, 3)
-  debug_pars <- res2$details[[1]]$pars
-  expect_equal(dim(debug_pars), c(2, 11, 30))
-  expect_equal(dimnames(debug_pars), list(c("a", "b"), NULL, NULL))
-  expect_equal(debug_pars[, 1, ], cbind(res2$initial, pars[, -30]))
-  expect_equal(debug_pars[, 11, ], pars)
+  debug_pars <- res2$details$pars
+  expect_equal(dim(debug_pars), c(2, 11, 30, 2))
+  expect_equal(debug_pars[, 1, 1, ], unname(res2$initial))
+  expect_equal(debug_pars[, 1, -1, ], unname(res2$pars)[, -30, ])
+  expect_equal(debug_pars[, 11, , ], unname(res2$pars))
 })
 
 
@@ -261,13 +259,13 @@ test_that("can continue a hmc model simultaneously, with debug", {
   set.seed(1)
   res1a <- monty_sample(m, sampler, 30, n_chains = 3, restartable = TRUE)
   res1b <- monty_sample_continue(res1a, 70)
-  ## We don't yet do a good job of auto squashing the details.  I'll
-  ## make this change in a future PR so it's more obvious (mrc-5293)
-  res1b$details <- observer_finalise_auto(res1b$details)
+
   set.seed(1)
   res2a <- monty_sample(m, sampler, 30, n_chains = 3, restartable = TRUE,
                         runner = runner)
   res2b <- monty_sample_continue(res2a, 70)
+
+  expect_equal(drop_runner(res1a), drop_runner(res2a))
 
   expect_equal(res1b, res2b)
   expect_equal(dim(res2b$details$pars), c(2, 11, 100, 3))

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -2,6 +2,7 @@ test_that("can draw samples from a trivial model", {
   m <- ex_simple_gamma1()
   sampler <- monty_sampler_random_walk(vcv = matrix(0.01, 1, 1))
   res <- monty_sample(m, sampler, 100)
+
   expect_equal(names(res),
                c("pars", "density", "initial", "details", "observations"))
   expect_equal(dim(res$pars), c(1, 100, 1))

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -117,11 +117,6 @@ test_that("can continue a simultaneous random walk sampler", {
   res2a <- monty_sample(m, sampler, 30, n_chains = 3, runner = runner,
                         restartable = TRUE)
 
-  ## This is good, except runner which we expect to vary.
-  drop_runner <- function(x) {
-    x$restart$runner <- NULL
-    x
-  }
   expect_equal(drop_runner(res2a), drop_runner(res1a))
 
   res2b <- monty_sample_continue(res2a, 70)

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -3,8 +3,9 @@ test_that("can draw samples from a trivial model", {
   sampler <- monty_sampler_random_walk(vcv = matrix(0.01, 1, 1))
   res <- monty_sample(m, sampler, 100)
 
-  expect_equal(names(res),
-               c("pars", "density", "initial", "details", "observations"))
+  expect_equal(
+    names(res),
+    c("pars", "density", "initial", "details", "state", "observations"))
   expect_equal(dim(res$pars), c(1, 100, 1))
 })
 
@@ -31,8 +32,9 @@ test_that("can draw samples from a random model", {
   vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
   sampler <- monty_sampler_random_walk(vcv = vcv)
   res <- monty_sample(m, sampler, 20)
-  expect_setequal(names(res),
-                  c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "state", "observations"))
 })
 
 
@@ -44,8 +46,9 @@ test_that("can observe a model", {
   ## This takes quite a while, and that seems mostly to be the time
   ## taken to call the filter in dust.
   res <- monty_sample(m, sampler, 20, n_chains = 3)
-  expect_setequal(names(res),
-                  c("pars", "density", "initial", "details", "observations"))
+  expect_setequal(
+    names(res),
+    c("pars", "density", "initial", "details", "state", "observations"))
   expect_equal(names(res$observations),
                "trajectories")
   expect_equal(dim(res$observations$trajectories),
@@ -114,11 +117,13 @@ test_that("can continue a simultaneous random walk sampler", {
   res2a <- monty_sample(m, sampler, 30, n_chains = 3, runner = runner,
                         restartable = TRUE)
 
-  drop_sampler_state <- function(x) {
-    x[names(x) != "sampler"]
+  ## This is good, except runner which we expect to vary.
+  drop_runner <- function(x) {
+    x$restart$runner <- NULL
+    x
   }
-  expect_equal(lapply(res2a$restart$state, drop_sampler_state),
-               lapply(res1a$restart$state, drop_sampler_state))
+  expect_equal(drop_runner(res2a), drop_runner(res1a))
+
   res2b <- monty_sample_continue(res2a, 70)
 
   expect_equal(res2b, res1b)

--- a/tests/testthat/test-sampler.R
+++ b/tests/testthat/test-sampler.R
@@ -1,0 +1,33 @@
+test_that("construct empty sampler state", {
+  state <- monty_sampler2_state(NULL, NULL, NULL, NULL)
+  expect_null(state$dump())
+  expect_null(state$restore())
+  expect_null(state$combine())
+  expect_null(state$details())
+})
+
+
+test_that("error if dump provided but other functions are not", {
+  expect_error(
+    monty_sampler2_state(identity, NULL, NULL, NULL),
+    "Missing state handling functions: 'state_restore' and 'state_combine'")
+  expect_error(
+    monty_sampler2_state(identity, NULL, identity, NULL),
+    "Missing state handling function: 'state_combine'")
+})
+
+
+test_that("Allow restore even where dump is missing", {
+  state <- monty_sampler2_state(NULL, NULL, identity, NULL)
+  expect_identical(state$restore, identity)
+})
+
+
+test_that("Don't allow other functions if dump is missing", {
+  expect_error(
+    monty_sampler2_state(NULL, identity, NULL, NULL),
+    "Unexpected state handling function provided: 'state_combine'")
+  expect_error(
+    monty_sampler2_state(NULL, identity, NULL, identity),
+    "Unexpected state handling functions provided: 'state_combine'")
+})

--- a/tests/testthat/test-sampler.R
+++ b/tests/testthat/test-sampler.R
@@ -31,3 +31,24 @@ test_that("Don't allow other functions if dump is missing", {
     monty_sampler2_state(NULL, identity, NULL, identity),
     "Unexpected state handling functions provided: 'state_combine'")
 })
+
+
+test_that("can create a custom sampler", {
+  ## This also acts as a test that we can construct a stateless
+  ## sampler.
+  toy_sampler <- function(sd) {
+    control <- list(sd = sd)
+    monty_sampler2(
+      "Toy Sampler",
+      "toy_sampler",
+      control,
+      toy_sampler_initialise,
+      toy_sampler_step)
+  }
+
+  sampler <- toy_sampler(rep(0.2, 5))
+  model <- monty_example("gaussian", diag(5))
+  samples1 <- monty_sample(model, sampler, 100, restartable = TRUE)
+  samples2 <- monty_sample_continue(samples1, 50)
+  expect_s3_class(samples2, "monty_samples")
+})


### PR DESCRIPTION
This PR tidies up the state handling in quite a disruptive way, but leaves us in a position where it is possible to reason about how state is actually stored.  Effectively this means that old style samplers cannot be used any longer but I'll formally remove those in the next PR.

The problem is that the state produced by a simultaneous runner looks very different to that of the separate chains.  In  the version on `main` have some code to convert the combined chains to look like individual chains, which is a bit sad because the combined chains look much nicer.  All the code for state management is spread everywhere and is a bit gross.

Here, we formalise this by having a "dump" phase where every sampler can eject state, a combine phase where the results of multiple chains are stitched together, a restore phase where a sampler is re-created and a details phase where we produce user-facing output.

It's likely that some higher level functions can be written to help create these, but I've not done that.  The state management for the existing samplers is fiddly but not that bad.