### PR TITLE
Fix coverage holes

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -408,38 +408,6 @@ initial_rng <- function(n_chains, seed = NULL) {
 }
 
 
-initial_rng_state <- function(n_chains, seed = NULL) {
-  matrix(unlist(monty_rng_distributed_state(n_nodes = n_chains, seed = seed)),
-         ncol = n_chains)
-}
-
-
-restart_data <- function(res, model, sampler, runner, thinning_factor) {
-  if (is.null(names(res))) {
-    state <- lapply(res, function(x) x$internal$state)
-  } else {
-    ## Prevented elsewhere, requires the filter to be rewritten a bit.
-    stopifnot(is.null(res$internal$state$model_rng))
-    n_chains <- length(res$internal$state$chain$density)
-    state <- lapply(seq_len(n_chains), function(i) {
-      list(chain = list(
-             pars = res$internal$state$chain$pars[, i],
-             density = res$internal$state$chain$density[i],
-             observation = NULL),
-           rng = res$internal$state$rng[[i]],
-           sampler = res$internal$state$sampler[[i]],
-           model_rng = NULL)
-    })
-  }
-  list(state = state,
-       model = model,
-       sampler = sampler,
-       runner = runner,
-       thinning_factor = thinning_factor)
-}
-
-
-
 direct_sample_within_domain <- function(model, rng, max_attempts = 100) {
   for (i in seq_len(max_attempts)) {
     x <- model$direct_sample(rng)

--- a/R/sampler-adaptive.R
+++ b/R/sampler-adaptive.R
@@ -505,11 +505,15 @@ sampler_random_walk_adaptive_state_dump <- function(state, control) {
 sampler_random_walk_adaptive_state_restore <- function(chain_id, state_chain,
                                                        state_sampler, control,
                                                        model) {
-  state <- lapply(state_sampler, array_select_last, chain_id)
-  state$history_pars <- as.vector(state$history_pars)
   if (length(chain_id) > 1) {
+    state <- state_sampler
     state$iteration <- state$iteration[[1]]
     state$weight <- state$weight[[1]]
+    state$scaling_history <- as.vector(t(state$scaling_history))
+    state$history_pars <- as.vector(aperm(state$history_pars, c(1, 3, 2)))
+  } else {
+    state <- lapply(state_sampler, array_select_last, chain_id)
+    state$history_pars <- as.vector(state$history_pars)
   }
   list2env(state, parent = emptyenv())
 }

--- a/R/sampler-random-walk.R
+++ b/R/sampler-random-walk.R
@@ -124,7 +124,7 @@ sampler_random_walk_dump <- function(state, control) {
   if (is.null(state$rerun)) {
     return(NULL)
   }
-  list(rerun_state = attr(state$rerun, "data"))$step
+  list(rerun_state = attr(state$rerun, "data")$i)
 }
 
 
@@ -132,6 +132,9 @@ sampler_random_walk_combine <- function(state, control) {
   if (all(vlapply(state, is.null))) {
     return(NULL)
   }
+  ## The only state that is saved is the rerun state, which is just a
+  ## counter of the steps taken. That is the same over all chains so
+  ## just get the first.
   state[[1]]
 }
 

--- a/tests/testthat/test-arrays.R
+++ b/tests/testthat/test-arrays.R
@@ -122,6 +122,12 @@ test_that("can bind together by adding a dimension", {
   res3 <- array_bind(arrays = list(m1, m2), before = 1)
   expect_equal(res3[1, , ], m1)
   expect_equal(res3[2, , ], m2)
+
+  expect_equal(array_bind(m1, m2, on = 0), res3)
+
+  expect_error(array_bind(m1, m2, on = 12),
+               "Invalid value for 'on' (12), must be in [0, 3]",
+               fixed = TRUE)
 })
 
 
@@ -250,4 +256,15 @@ test_that("preserve names dropping to vector", {
   m2 <- random_array(c(1, 5))
   dimnames(m2) <- list("x", letters[1:5])
   expect_equal(array_drop(m2, 1), set_names(c(m2), letters[1:5]))
+})
+
+
+test_that("Can get the last entry in an array", {
+  expect_equal(array_select_last(list(1, 2, 3, 4), 2), 2)
+  expect_equal(array_select_last(1:4, 2), 2)
+  expect_equal(array_select_last(matrix(1:6, 2, 3), 2), cbind(3:4))
+  expect_equal(array_select_last(array(1:24, c(2, 3, 4)), 2),
+               array(7:12, c(2, 3, 1)))
+  expect_error(array_select_last(array(1:120, c(2, 3, 4, 5)), 2),
+               "unsupported access")
 })

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -228,3 +228,22 @@ test_that("can validate forget rate", {
   expect_error(validate_forget_rate(-1),
                "Expected 'forget_rate' to be positive")
 })
+
+
+test_that("can continue adaptive sampler simultaneously", {
+  m <- ex_simple_gamma1()
+  sampler <- monty_sampler_adaptive(initial_vcv = matrix(0.01, 1, 1))
+  runner <- monty_runner_simultaneous()
+
+  set.seed(1)
+  res1a <- monty_sample(m, sampler, 10, n_chains = 3, restartable = TRUE)
+  res1b <- monty_sample_continue(res1a, 20)
+
+  set.seed(1)
+  res2a <- monty_sample(m, sampler, 10, n_chains = 3, runner = runner,
+                        restartable = TRUE)
+  res2b <- monty_sample_continue(res2a, 20)
+
+  expect_equal(drop_runner(res1a), drop_runner(res2a))
+  expect_equal(res1b, res2b)
+})

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -266,3 +266,21 @@ test_that("Can rerun a stochastic model", {
   expect_true(all(change_density1[seq(1, 20, by = 2)]))
   expect_false(all(change_density2[seq(1, 20, by = 2)]))
 })
+
+
+test_that("can continue periodic rerun models", {
+  set.seed(1)
+  m <- ex_sir_filter_posterior()
+  vcv <- matrix(c(0.0006405, 0.0005628, 0.0005628, 0.0006641), 2, 2)
+  sampler <- monty_sampler_random_walk(vcv = vcv, rerun_every = 7,
+                                       rerun_random = FALSE)
+
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, 30, n_chains = 2)
+
+  set.seed(1)
+  res2a <- monty_sample(m, sampler, 10, n_chains = 2, restartable = TRUE)
+  res2b <- monty_sample_continue(res2a, 20)
+
+  expect_equal(res1, res2b)
+})


### PR DESCRIPTION
Merge after #165, contains those commits.

This PR just fixes up gaps in coverage introduced by this set of PRs; it ignores the handful of other existing holes. In doing so it fixes resume-related bugs in both the rw sampler (where we had period reset) and the adaptive rw sampler (where we used the simultaneous runner)