### PR TITLE
Tune beta values in parallel tempering

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/example.R
+++ b/R/example.R
@@ -12,7 +12,7 @@
 ##'
 ##' # Supported models:
 ##'
-##' Each model has a **arguments** that are passed through as `...` in
+##' Each model has **arguments** that are passed through as `...` in
 ##' `monty_example` and are used to set up the example.  This creates
 ##' a `monty_model` object that will accept **parameters**, which are
 ##' the values in the argument `parameters` passed to

--- a/R/example.R
+++ b/R/example.R
@@ -1,69 +1,88 @@
-#' Example models for \pkg{monty}
-#'
-#' Load small, ready-made target distributions for demonstrations, tests,
-#' and examples. These models exist so that we can create (hopefully)
-#' interesting examples in the documentation without them becoming
-#' overwhelming. All examples contain an analytic gradient and can
-#' thus be also used to explore gradient-based samplers such as
-#' \link{monty_sampler_hmc}.
-#'
-#' @section Supported models:
-#' \describe{
-#'   \item{\code{"banana"}}{A two-dimensional “banana”-shaped target with
-#'   strong local correlation; useful for illustrating the limitations of
-#'   random-walk proposals. Tunable by \code{sigma}.}
-#'
-#'   \item{\code{"gaussian"}}{A centred multivariate Gaussian \eqn{N(0, \Sigma)}
-#'   with user-supplied variance–covariance matrix \eqn{\Sigma}.}
-#'
-#'   \item{\code{"ring"}}{A two-dimensional ring-shaped density whose
-#'   log-density is proportional to \eqn{-(\|x\|-r)^2/(2\,sd^2)}. Includes an
-#'   analytic gradient and a direct sampler in polar coordinates.}
-#'
-#'   \item{\code{"mixture2d"}}{An equal-weight mixture of \eqn{k} isotropic
-#'   2D Gaussians with standard deviation \code{sd} and centres either
-#'   provided by the user (\code{means}) or drawn uniformly in a square of
-#'   half-width \code{spread}. Includes an analytic gradient.}
-#' }
-#'
-#' @param name String giving the model name. One of
-#'   \code{"banana"}, \code{"gaussian"}, \code{"ring"}, \code{"mixture2d"}.
-#' @param ... Additional arguments forwarded to the specific model
-#'   constructor (see sections below for each model’s parameters).
-#'
-#' @return A \link{monty_model} object with fields \code{parameters},
-#'   \code{density} (log-density), \code{gradient}, \code{direct_sample}
-#'   (where available), and \code{domain}. All returned models set
-#'   \code{properties = monty_model_properties(allow_multiple_parameters = TRUE)}
-#'   so they can be evaluated for parameter matrices.
-#'
-#' @details
-#' These models are primarily intended for examples, unit tests, and
-#' teaching materials. They aim to be simple but non‑trivial, and they
-#' expose analytic gradients when that’s helpful for HMC/NUTS.
-#'
-#' @examples
-#' # Banana target
-#' m1 <- monty_example("banana")                   # default sigma = 0.5
-#' m2 <- monty_example("banana", sigma = 0.2)
-#'
-#' # 2D Gaussian with diagonal covariance
-#' m3 <- monty_example("gaussian", diag(2))
-#'
-#' # Ring target with radius 3 and narrow thickness
-#' m4 <- monty_example("ring", r = 3, sd = 0.25)
-#'
-#' # 2D Gaussian mixture with 12 components
-#' m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4, seed = 42)
-#'
-#' @seealso \link{monty_model}, \link{monty_model_properties}
-#' @export
+##' Load example models from monty.  These models exist so that we can
+##' create (hopefully) interesting examples in the documentation
+##' without them becoming overwhelming.  You should probably not use
+##' these for anything other than exploring the package.
+##'
+##' Load small, ready-made target distributions for demonstrations, tests,
+##' and examples. These models exist so that we can create (hopefully)
+##' interesting examples in the documentation without them becoming
+##' overwhelming. All examples contain an analytic gradient and can
+##' thus be also used to explore gradient-based samplers such as
+##' [monty_sampler_hmc].
+##'
+##' # Supported models:
+##'
+##' Each model has a **arguments** that are passed through as `...` in
+##' `monty_example` and are used to set up the example.  This creates
+##' a `monty_model` object that will accept **parameters**, which are
+##' the values in the argument `parameters` passed to
+##' `monty_model_density`.
+##'
+##' ## `banana`
+##'
+##' The banana model is a two-dimensional banana-shaped function, with
+##' strong local correlation.  This example was picked because it is
+##' useful for illustrating the limitations of random-walk proposals.
+##' The model has two parameters `alpha` and `beta` and is based on
+##' two successive draws, one conditional on the other.
+##'
+##' You can vary the argument `sigma` for this model on creation, the
+##' default is 0.5
+##'
+##' ## `gaussian`
+##'
+##' A multivariate Gaussian centred at the origin.  Takes a
+##' variance-covariance-matrix as its argument.  Parameters are
+##' letters a, b, ... up to the number of dimensions.
+##'
+##' ## `ring`
+##'
+##' A two-dimensional ring-shaped density whose log-density is
+##' proportional to $-(\|x\|-r)^2/(2\,sd^2)$.  Includes an analytic
+##' gradient and a direct sampler in polar coordinates.  The
+##' constructor takes that arguments `r` and `sd`, and the parameters
+##' of the `monty_model` are `x1` and `x2` (corresponding to the two
+##' dimensions of the polar coordinates).
+##'
+##' ## `mixture2d`
+##'
+##' An equal-weight mixture of `k` isotropic 2D Gaussians with
+##' standard deviation `sd` and centres either provided by the
+##' argument (`means`) or drawn uniformly in a square of half-width
+##' `spread`. Includes an analytic gradient.
+##'
+##' @param name Name of the example, as a string.  See Details for
+##'   supported models.
+##'
+##' @param ... Optional parameters that are passed to create the
+##'   model.  All models can be created with no additional parameters,
+##'   but you can tweak their behaviour by passing named parameters
+##'   here.  See Details.
+##'
+##' @return A [monty_model] object.
+##'
+##' @seealso [monty_model], [monty_model_properties]
+##' @export
+##'
+##' @examples
+##' # Banana target
+##' m1 <- monty_example("banana")
+##' m2 <- monty_example("banana", sigma = 0.2)
+##'
+##' # 2D Gaussian with diagonal covariance
+##' m3 <- monty_example("gaussian", diag(2))
+##'
+##' # Ring target with radius 3 and narrow thickness
+##' m4 <- monty_example("ring", r = 3, sd = 0.25)
+##'
+##' # 2D Gaussian mixture with 12 components
+##' m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4)
 monty_example <- function(name, ...) {
   examples <- list(
-    banana      = monty_example_banana,
-    gaussian    = monty_example_gaussian,
-    ring        = monty_example_ring,
-    mixture2d   = monty_example_gaussian_mixture2d
+    banana = monty_example_banana,
+    gaussian = monty_example_gaussian,
+    ring = monty_example_ring,
+    mixture2d = monty_example_gaussian_mixture2d
   )
   examples[[match_value(name, names(examples))]](...)
 }
@@ -127,7 +146,7 @@ monty_example_gaussian <- function(vcv) {
 
 monty_example_ring <- function(r = 3, sd = 0.2) {
   stopifnot(sd > 0, r >= 0)
-  
+
   ring_log_density <- function(x) {
     if (is.matrix(x)) {
       x1  <- x[1, ]
@@ -141,7 +160,7 @@ monty_example_ring <- function(r = 3, sd = 0.2) {
       -(rho - r)^2 / (2 * sd * sd)
     }
   }
-  
+
   ring_gradient <- function(x) {
     if (is.matrix(x)) {
       x1  <- x[1, ]
@@ -165,50 +184,52 @@ monty_example_ring <- function(r = 3, sd = 0.2) {
       }
     }
   }
-  
+
+  ring_direct_sample <- function(rng) {
+    theta <- runif(1, 0, 2 * pi)
+    rad   <- monty_random_normal(r, sd, rng)
+    c(rad * cos(theta), rad * sin(theta))
+  }
+
+  properties <- monty_model_properties(allow_multiple_parameters = TRUE)
+
   monty_model(
-    list(
-      parameters = c("x1", "x2"),
-      direct_sample = function(rng) {
-        theta <- runif(1, 0, 2 * pi)
-        rad   <- monty_random_normal(r, sd, rng)
-        c(rad * cos(theta), rad * sin(theta))
-      },
-      density  = ring_log_density,  # log-density up to a constant
-      gradient = ring_gradient,
-      domain   = rbind(c(-Inf, Inf), c(-Inf, Inf))
-    ),
-    properties = monty_model_properties(allow_multiple_parameters = TRUE)
-  )
+    list(parameters = c("x1", "x2"),
+         direct_sample = ring_direct_sample,
+         density = ring_log_density,
+         gradient = ring_gradient,
+         domain = rbind(c(-Inf, Inf), c(-Inf, Inf))),
+    properties = properties)
 }
 
 
 monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = 3,
-                                             means = NULL, seed = NULL) {
+                                             means = NULL) {
+  ## TODO: use proper assertions
   stopifnot(k >= 1, sd > 0, spread > 0)
-  if (!is.null(seed)) set.seed(seed)
   if (is.null(means)) {
     means <- cbind(runif(k, -spread, spread), runif(k, -spread, spread))
   } else {
     means <- as.matrix(means)
     stopifnot(ncol(means) == 2, nrow(means) == k)
   }
-  
+
   log_const <- -log(2 * pi * sd * sd)
-  
+
   ## Compute log N_2(x | mu_i, sd^2 I) for a x
   log_phi_one <- function(x) {
     dx <- x[1] - means[, 1]
     dy <- x[2] - means[, 2]
     log_const - 0.5 * (dx * dx + dy * dy) / (sd * sd)
   }
-  
+
   ## Numerically stable log-sum-exp
   lse <- function(v) {
     m <- max(v)
     m + log(sum(exp(v - m)))
   }
-  
+
+  ## TODO: try and harmonise the vector and non-multi-parameter forms here
   density_fun <- function(x) {
     if (is.matrix(x)) {
       out <- numeric(ncol(x))
@@ -222,7 +243,7 @@ monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = 3,
       -log(k) + lse(lp)
     }
   }
-  
+
   gradient_fun <- function(x) {
     inv_var <- 1 / (sd * sd)
     if (is.matrix(x)) {
@@ -230,11 +251,11 @@ monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = 3,
       gy <- numeric(ncol(x))
       for (j in seq_len(ncol(x))) {
         xx <- c(x[1, j], x[2, j])
-        lp <- log_phi_one(xx)            # length k
-        log_w_unnorm <- -log(k) + lp     # equal weights
+        lp <- log_phi_one(xx)
+        log_w_unnorm <- -log(k) + lp
         m  <- max(log_w_unnorm)
-        w  <- exp(log_w_unnorm - (m + log(sum(exp(log_w_unnorm - m)))))  # normalised
-        # ∑_i w_i (x - mu_i)
+        w  <- exp(log_w_unnorm - (m + log(sum(exp(log_w_unnorm - m)))))
+        # sum_i w_i (x - mu_i)
         mx <- sum(w * (xx[1] - means[, 1]))
         my <- sum(w * (xx[2] - means[, 2]))
         gx[j] <- -inv_var * mx
@@ -252,21 +273,21 @@ monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = 3,
       -inv_var * c(mx, my)
     }
   }
-  
+
+  direct_sample <- function(rng) {
+    ## TODO: don't use R's RNG
+    i <- sample.int(k, 1)
+    c(monty_random_normal(means[i, 1], sd, rng),
+      monty_random_normal(means[i, 2], sd, rng))
+  }
+
+  properties <- monty_model_properties(allow_multiple_parameters = TRUE)
+
   monty_model(
-    list(
-      parameters = c("x1", "x2"),
-      direct_sample = function(rng) {
-        i <- sample.int(k, 1)
-        c(
-          monty_random_normal(means[i, 1], sd, rng),
-          monty_random_normal(means[i, 2], sd, rng)
-        )
-      },
-      density  = density_fun,   # proper log-density (mixture is normalised)
-      gradient = gradient_fun,
-      domain   = rbind(c(-Inf, Inf), c(-Inf, Inf))
-    ),
-    properties = monty_model_properties(allow_multiple_parameters = TRUE)
-  )
+    list(parameters = c("x1", "x2"),
+         direct_sample = direct_sample,
+         density  = density_fun,   # proper log-density (mixture is normalised)
+         gradient = gradient_fun,
+         domain   = rbind(c(-Inf, Inf), c(-Inf, Inf))),
+    properties = properties)
 }

--- a/R/example.R
+++ b/R/example.R
@@ -214,27 +214,32 @@ monty_example_ring <- function(r = 3, sd = 0.2) {
 
 
 monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = NULL,
-                                             means = NULL) {
+                                             means = NULL,
+                                             call = parent.frame()) {
   assert_scalar_positive_integer(k, allow_zero = FALSE)
   assert_scalar_positive_numeric(sd, allow_zero = FALSE)
   if (is.null(means)) {
-    assert_scalar_positive_numeric(sd, allow_zero = FALSE)
+    assert_scalar_positive_numeric(spread, allow_zero = FALSE, call = call)
     means <- cbind(runif(k, -spread, spread), runif(k, -spread, spread))
   } else {
     if (!is.null(spread)) {
       cli::cli_abort(
         c("Do not provide 'spread' if providing 'means'",
           i = paste("'spread' is used to randomly sample 'means' if it is",
-                    "not given, but you are providing 'means' here already")))
+                    "not given, but you are providing 'means' here already")),
+        arg = "spread", call = call)
     }
-    if (!is.matrx(means)) {
-      cli::cli_abort("Expected 'means' to be a matrix")
+    if (!is.matrix(means)) {
+      cli::cli_abort("Expected 'means' to be a matrix",
+                     arg = "means", call = call)
     }
     if (ncol(means) != 2) {
-      cli::cli_abort("Expected 'means' to have two columns")
+      cli::cli_abort("Expected 'means' to have 2 columns",
+                     arg = "means", call = call)
     }
-    if (ncol(means) != 2) {
-      cli::cli_abort("Expected 'means' to have {k} row{?s}")
+    if (nrow(means) != k) {
+      cli::cli_abort("Expected 'means' to have {k} row{?s}",
+                     arg = "means", call = call)
     }
   }
 
@@ -299,7 +304,7 @@ monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = NULL,
   }
 
   direct_sample <- function(rng) {
-    i <- ceiling(monty_random_real(k))
+    i <- ceiling(monty_random_real(rng) * k)
     c(monty_random_normal(means[i, 1], sd, rng),
       monty_random_normal(means[i, 2], sd, rng))
   }

--- a/R/example.R
+++ b/R/example.R
@@ -1,44 +1,70 @@
-##' Load example models from monty.  These models exist so that we can
-##' create (hopefully) interesting examples in the documentation
-##' without them becoming overwhelming.  You should probably not use
-##' these for anything other than exploring the package.
-##'
-##' # Supported models
-##'
-##' ## `banana`
-##'
-##' The banana model is a two-dimensional banana-shaped function,
-##' picked because it is quite annoying to sample from directly.  The
-##' model has two parameters `alpha` and `beta` and is based on two
-##' successive draws, one conditional on the other.
-##'
-##' You can vary `sigma` for this model on creation, the default is 0.5
-##'
-##' ## Gaussian
-##'
-##' A multivariate Gaussian centred at the origin.  Takes a
-##' variance-covariance-matrix as its argument.  Parameters are
-##' letters a, b, ... up to the number of dimensions.
-##'
-##' @title Example models
-##'
-##' @param name Name of the example, as a string.  See Details for
-##'   supported models.
-##'
-##' @param ... Optional parameters that are passed to create the
-##'   model.  All models can be created with no additional parameters,
-##'   but you can tweak their behaviour by passing named parameters
-##'   here.  See Details.
-##'
-##' @return A [monty_model] object
-##' @export
-##'
-##' @examples
-##' monty_example("banana")
-##' monty_example("gaussian", diag(2))
+#' Example models for \pkg{monty}
+#'
+#' Load small, ready-made target distributions for demonstrations, tests,
+#' and examples. These models exist so that we can create (hopefully)
+#' interesting examples in the documentation without them becoming
+#' overwhelming. All examples contain an analytic gradient and can
+#' thus be also used to explore gradient-based samplers such as
+#' \link{monty_sampler_hmc}.
+#'
+#' @section Supported models:
+#' \describe{
+#'   \item{\code{"banana"}}{A two-dimensional “banana”-shaped target with
+#'   strong local correlation; useful for illustrating the limitations of
+#'   random-walk proposals. Tunable by \code{sigma}.}
+#'
+#'   \item{\code{"gaussian"}}{A centred multivariate Gaussian \eqn{N(0, \Sigma)}
+#'   with user-supplied variance–covariance matrix \eqn{\Sigma}.}
+#'
+#'   \item{\code{"ring"}}{A two-dimensional ring-shaped density whose
+#'   log-density is proportional to \eqn{-(\|x\|-r)^2/(2\,sd^2)}. Includes an
+#'   analytic gradient and a direct sampler in polar coordinates.}
+#'
+#'   \item{\code{"mixture2d"}}{An equal-weight mixture of \eqn{k} isotropic
+#'   2D Gaussians with standard deviation \code{sd} and centres either
+#'   provided by the user (\code{means}) or drawn uniformly in a square of
+#'   half-width \code{spread}. Includes an analytic gradient.}
+#' }
+#'
+#' @param name String giving the model name. One of
+#'   \code{"banana"}, \code{"gaussian"}, \code{"ring"}, \code{"mixture2d"}.
+#' @param ... Additional arguments forwarded to the specific model
+#'   constructor (see sections below for each model’s parameters).
+#'
+#' @return A \link{monty_model} object with fields \code{parameters},
+#'   \code{density} (log-density), \code{gradient}, \code{direct_sample}
+#'   (where available), and \code{domain}. All returned models set
+#'   \code{properties = monty_model_properties(allow_multiple_parameters = TRUE)}
+#'   so they can be evaluated for parameter matrices.
+#'
+#' @details
+#' These models are primarily intended for examples, unit tests, and
+#' teaching materials. They aim to be simple but non‑trivial, and they
+#' expose analytic gradients when that’s helpful for HMC/NUTS.
+#'
+#' @examples
+#' # Banana target
+#' m1 <- monty_example("banana")                   # default sigma = 0.5
+#' m2 <- monty_example("banana", sigma = 0.2)
+#'
+#' # 2D Gaussian with diagonal covariance
+#' m3 <- monty_example("gaussian", diag(2))
+#'
+#' # Ring target with radius 3 and narrow thickness
+#' m4 <- monty_example("ring", r = 3, sd = 0.25)
+#'
+#' # 2D Gaussian mixture with 12 components
+#' m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4, seed = 42)
+#'
+#' @seealso \link{monty_model}, \link{monty_model_properties}
+#' @export
 monty_example <- function(name, ...) {
-  examples <- list(banana = monty_example_banana,
-                   gaussian = monty_example_gaussian)
+  examples <- list(
+    banana      = monty_example_banana,
+    gaussian    = monty_example_gaussian,
+    ring        = monty_example_ring,
+    mixture2d   = monty_example_gaussian_mixture2d
+  )
   examples[[match_value(name, names(examples))]](...)
 }
 
@@ -96,4 +122,151 @@ monty_example_gaussian <- function(vcv) {
     density = make_ldmvnorm(vcv),
     gradient = make_deriv_ldmvnorm(vcv),
     domain = cbind(rep(-Inf, n), rep(Inf, n))))
+}
+
+
+monty_example_ring <- function(r = 3, sd = 0.2) {
+  stopifnot(sd > 0, r >= 0)
+  
+  ring_log_density <- function(x) {
+    if (is.matrix(x)) {
+      x1  <- x[1, ]
+      x2  <- x[2, ]
+      rho <- sqrt(x1 * x1 + x2 * x2)
+      -(rho - r)^2 / (2 * sd * sd)
+    } else {
+      x1  <- x[[1]]
+      x2  <- x[[2]]
+      rho <- sqrt(x1 * x1 + x2 * x2)
+      -(rho - r)^2 / (2 * sd * sd)
+    }
+  }
+  
+  ring_gradient <- function(x) {
+    if (is.matrix(x)) {
+      x1  <- x[1, ]
+      x2  <- x[2, ]
+      rho <- sqrt(x1 * x1 + x2 * x2)
+      # handle rho = 0 gracefully
+      rho_safe <- ifelse(rho == 0, 1, rho)
+      scale <- -(rho - r) / (sd * sd * rho_safe)
+      gx <- scale * x1
+      gy <- scale * x2
+      rbind(gx, gy, deparse.level = 0)
+    } else {
+      x1  <- x[[1]]
+      x2  <- x[[2]]
+      rho <- sqrt(x1 * x1 + x2 * x2)
+      if (rho == 0) {
+        c(0, 0)
+      } else {
+        scale <- -(rho - r) / (sd * sd * rho)
+        c(scale * x1, scale * x2)
+      }
+    }
+  }
+  
+  monty_model(
+    list(
+      parameters = c("x1", "x2"),
+      direct_sample = function(rng) {
+        theta <- runif(1, 0, 2 * pi)
+        rad   <- monty_random_normal(r, sd, rng)
+        c(rad * cos(theta), rad * sin(theta))
+      },
+      density  = ring_log_density,  # log-density up to a constant
+      gradient = ring_gradient,
+      domain   = rbind(c(-Inf, Inf), c(-Inf, Inf))
+    ),
+    properties = monty_model_properties(allow_multiple_parameters = TRUE)
+  )
+}
+
+
+monty_example_gaussian_mixture2d <- function(k = 8, sd = 0.4, spread = 3,
+                                             means = NULL, seed = NULL) {
+  stopifnot(k >= 1, sd > 0, spread > 0)
+  if (!is.null(seed)) set.seed(seed)
+  if (is.null(means)) {
+    means <- cbind(runif(k, -spread, spread), runif(k, -spread, spread))
+  } else {
+    means <- as.matrix(means)
+    stopifnot(ncol(means) == 2, nrow(means) == k)
+  }
+  
+  log_const <- -log(2 * pi * sd * sd)
+  
+  ## Compute log N_2(x | mu_i, sd^2 I) for a x
+  log_phi_one <- function(x) {
+    dx <- x[1] - means[, 1]
+    dy <- x[2] - means[, 2]
+    log_const - 0.5 * (dx * dx + dy * dy) / (sd * sd)
+  }
+  
+  ## Numerically stable log-sum-exp
+  lse <- function(v) {
+    m <- max(v)
+    m + log(sum(exp(v - m)))
+  }
+  
+  density_fun <- function(x) {
+    if (is.matrix(x)) {
+      out <- numeric(ncol(x))
+      for (j in seq_len(ncol(x))) {
+        lp <- log_phi_one(c(x[1, j], x[2, j]))
+        out[j] <- -log(k) + lse(lp)  # log( (1/k)*sum phi_i )
+      }
+      out
+    } else {
+      lp <- log_phi_one(c(x[[1]], x[[2]]))
+      -log(k) + lse(lp)
+    }
+  }
+  
+  gradient_fun <- function(x) {
+    inv_var <- 1 / (sd * sd)
+    if (is.matrix(x)) {
+      gx <- numeric(ncol(x))
+      gy <- numeric(ncol(x))
+      for (j in seq_len(ncol(x))) {
+        xx <- c(x[1, j], x[2, j])
+        lp <- log_phi_one(xx)            # length k
+        log_w_unnorm <- -log(k) + lp     # equal weights
+        m  <- max(log_w_unnorm)
+        w  <- exp(log_w_unnorm - (m + log(sum(exp(log_w_unnorm - m)))))  # normalised
+        # ∑_i w_i (x - mu_i)
+        mx <- sum(w * (xx[1] - means[, 1]))
+        my <- sum(w * (xx[2] - means[, 2]))
+        gx[j] <- -inv_var * mx
+        gy[j] <- -inv_var * my
+      }
+      rbind(gx, gy, deparse.level = 0)
+    } else {
+      xx <- c(x[[1]], x[[2]])
+      lp <- log_phi_one(xx)
+      log_w_unnorm <- -log(k) + lp
+      m  <- max(log_w_unnorm)
+      w  <- exp(log_w_unnorm - (m + log(sum(exp(log_w_unnorm - m)))))
+      mx <- sum(w * (xx[1] - means[, 1]))
+      my <- sum(w * (xx[2] - means[, 2]))
+      -inv_var * c(mx, my)
+    }
+  }
+  
+  monty_model(
+    list(
+      parameters = c("x1", "x2"),
+      direct_sample = function(rng) {
+        i <- sample.int(k, 1)
+        c(
+          monty_random_normal(means[i, 1], sd, rng),
+          monty_random_normal(means[i, 2], sd, rng)
+        )
+      },
+      density  = density_fun,   # proper log-density (mixture is normalised)
+      gradient = gradient_fun,
+      domain   = rbind(c(-Inf, Inf), c(-Inf, Inf))
+    ),
+    properties = monty_model_properties(allow_multiple_parameters = TRUE)
+  )
 }

--- a/R/sampler-parallel-tempering.R
+++ b/R/sampler-parallel-tempering.R
@@ -272,8 +272,6 @@ sampler_parallel_tempering_step <- function(state_chain, state_sampler,
   state_sampler$sub_state_chain <- sub_state_chain
   state_sampler$even_step <- !state_sampler$even_step
 
-  ## We track swap acceptances so that the beta values can be tuned,
-  ## though this not yet implemented.
   state_sampler$accept_swap[i1] <- state_sampler$accept_swap[i1] + accept
   state_sampler$attempt_swap[i1] <- state_sampler$attempt_swap[i1] + 1L
 

--- a/R/sampler-parallel-tempering.R
+++ b/R/sampler-parallel-tempering.R
@@ -137,11 +137,15 @@ sampler_parallel_tempering_update_beta <- function(beta,
   ## Compute normalised lambda (normalised cumulative rejection rate)
   lambda <- cumsum(r / sum(r))
 
+  ## The final lambda might not be strictly one due to floating point
+  ## issues, so fix that:
+  lambda[[length(lambda)]] <- 1
+
   ## The new betas are an interpolated set of beta values that would
   ## have given an equally spaced set of lambdas -- which is equal
   ## rejection rates for each pair:
-  suppressWarnings(
-    approx(lambda, beta, seq(0, 1, length.out = length(beta))))$y
+  at <- seq(0, 1, length.out = length(beta))
+  suppressWarnings(approx(lambda, beta, at))$y
 }
 
 

--- a/man/monty_example.Rd
+++ b/man/monty_example.Rd
@@ -30,7 +30,7 @@ thus be also used to explore gradient-based samplers such as
 \link{monty_sampler_hmc}.
 }
 \section{Supported models:}{
-Each model has a \strong{arguments} that are passed through as \code{...} in
+Each model has \strong{arguments} that are passed through as \code{...} in
 \code{monty_example} and are used to set up the example.  This creates
 a \code{monty_model} object that will accept \strong{parameters}, which are
 the values in the argument \code{parameters} passed to

--- a/man/monty_example.Rd
+++ b/man/monty_example.Rd
@@ -59,9 +59,13 @@ letters a, b, ... up to the number of dimensions.
 A two-dimensional ring-shaped density whose log-density is
 proportional to $-(\|x\|-r)^2/(2\,sd^2)$.  Includes an analytic
 gradient and a direct sampler in polar coordinates.  The
-constructor takes that arguments \code{r} and \code{sd}, and the parameters
-of the \code{monty_model} are \code{x1} and \code{x2} (corresponding to the two
-dimensions of the polar coordinates).
+constructor takes that arguments \code{r} (default 3) and \code{sd} (default
+0.2), and the parameters of the \code{monty_model} are \code{x1} and \code{x2}
+(corresponding to the two dimensions of the polar coordinates).
+
+Increasing \code{r} or decreasing \code{sd} will make the ridge of high
+probability space narrower; this is easiest to visualise in true
+densities (rather than log density).
 }
 
 \subsection{\code{mixture2d}}{
@@ -69,23 +73,34 @@ dimensions of the polar coordinates).
 An equal-weight mixture of \code{k} isotropic 2D Gaussians with
 standard deviation \code{sd} and centres either provided by the
 argument (\code{means}) or drawn uniformly in a square of half-width
-\code{spread}. Includes an analytic gradient.
+\code{spread} (which must be provided if \code{means} is not
+provided). Includes an analytic gradient.
 }
 }
 
 \examples{
-# Banana target
-m1 <- monty_example("banana")
-m2 <- monty_example("banana", sigma = 0.2)
+# Small helper function to make the plotting easier
+show_2d_example <- function(m, rx, ry = rx, n = 101) {
+  x <- seq(rx[[1]], rx[[2]], length.out = n)
+  y <- seq(ry[[1]], ry[[2]], length.out = n)
+  xy <- unname(t(as.matrix(expand.grid(x, y))))
+  z <- exp(matrix(monty_model_density(m, xy), n, n))
+  image(x, y, z)
+  contour(x, y, z, add = TRUE, drawlabels = FALSE,
+          lwd = 0.5, col = "#00000088")
+}
 
-# 2D Gaussian with diagonal covariance
-m3 <- monty_example("gaussian", diag(2))
+# Banana target
+m_banana <- monty_example("banana", sigma = 0.2)
+show_2d_example(m_banana, c(-0.5, 1.5), c(-1.5, 1.5))
 
 # Ring target with radius 3 and narrow thickness
-m4 <- monty_example("ring", r = 3, sd = 0.25)
+m_ring <- monty_example("ring", r = 3, sd = 0.25)
+show_2d_example(m_ring, c(-4, 4))
 
-# 2D Gaussian mixture with 12 components
-m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4)
+# 2D Gaussian mixture with 20 components
+m_mixture <- monty_example("mixture2d", k = 20, sd = 0.5, spread = 4)
+show_2d_example(m_mixture, c(-5, 5))
 }
 \seealso{
 \link{monty_model}, \link{monty_model_properties}

--- a/man/monty_example.Rd
+++ b/man/monty_example.Rd
@@ -2,48 +2,73 @@
 % Please edit documentation in R/example.R
 \name{monty_example}
 \alias{monty_example}
-\title{Example models}
+\title{Example models for \pkg{monty}}
 \usage{
 monty_example(name, ...)
 }
 \arguments{
-\item{name}{Name of the example, as a string.  See Details for
-supported models.}
+\item{name}{String giving the model name. One of
+\code{"banana"}, \code{"gaussian"}, \code{"ring"}, \code{"mixture2d"}.}
 
-\item{...}{Optional parameters that are passed to create the
-model.  All models can be created with no additional parameters,
-but you can tweak their behaviour by passing named parameters
-here.  See Details.}
+\item{...}{Additional arguments forwarded to the specific model
+constructor (see sections below for each model’s parameters).}
 }
 \value{
-A \link{monty_model} object
+A \link{monty_model} object with fields \code{parameters},
+\code{density} (log-density), \code{gradient}, \code{direct_sample}
+(where available), and \code{domain}. All returned models set
+\code{properties = monty_model_properties(allow_multiple_parameters = TRUE)}
+so they can be evaluated for parameter matrices.
 }
 \description{
-Load example models from monty.  These models exist so that we can
-create (hopefully) interesting examples in the documentation
-without them becoming overwhelming.  You should probably not use
-these for anything other than exploring the package.
+Load small, ready-made target distributions for demonstrations, tests,
+and examples. These models exist so that we can create (hopefully)
+interesting examples in the documentation without them becoming
+overwhelming. All examples contain an analytic gradient and can
+thus be also used to explore gradient-based samplers such as
+\link{monty_sampler_hmc}.
+}
+\details{
+These models are primarily intended for examples, unit tests, and
+teaching materials. They aim to be simple but non‑trivial, and they
+expose analytic gradients when that’s helpful for HMC/NUTS.
 }
 \section{Supported models}{
-\subsection{\code{banana}}{
 
-The banana model is a two-dimensional banana-shaped function,
-picked because it is quite annoying to sample from directly.  The
-model has two parameters \code{alpha} and \code{beta} and is based on two
-successive draws, one conditional on the other.
+\describe{
+\item{\code{"banana"}}{A two-dimensional “banana”-shaped target with
+strong local correlation; useful for illustrating the limitations of
+random-walk proposals. Tunable by \code{sigma}.}
 
-You can vary \code{sigma} for this model on creation, the default is 0.5
-}
+\item{\code{"gaussian"}}{A centred multivariate Gaussian \eqn{N(0, \Sigma)}
+with user-supplied variance–covariance matrix \eqn{\Sigma}.}
 
-\subsection{Gaussian}{
+\item{\code{"ring"}}{A two-dimensional ring-shaped density whose
+log-density is proportional to \eqn{-(\|x\|-r)^2/(2\,sd^2)}. Includes an
+analytic gradient and a direct sampler in polar coordinates.}
 
-A multivariate Gaussian centred at the origin.  Takes a
-variance-covariance-matrix as its argument.  Parameters are
-letters a, b, ... up to the number of dimensions.
+\item{\code{"mixture2d"}}{An equal-weight mixture of \eqn{k} isotropic
+2D Gaussians with standard deviation \code{sd} and centres either
+provided by the user (\code{means}) or drawn uniformly in a square of
+half-width \code{spread}. Includes an analytic gradient.}
 }
 }
 
 \examples{
-monty_example("banana")
-monty_example("gaussian", diag(2))
+# Banana target
+m1 <- monty_example("banana")                   # default sigma = 0.5
+m2 <- monty_example("banana", sigma = 0.2)
+
+# 2D Gaussian with diagonal covariance
+m3 <- monty_example("gaussian", diag(2))
+
+# Ring target with radius 3 and narrow thickness
+m4 <- monty_example("ring", r = 3, sd = 0.25)
+
+# 2D Gaussian mixture with 12 components
+m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4, seed = 42)
+
+}
+\seealso{
+\link{monty_model}, \link{monty_model_properties}
 }

--- a/man/monty_example.Rd
+++ b/man/monty_example.Rd
@@ -2,23 +2,24 @@
 % Please edit documentation in R/example.R
 \name{monty_example}
 \alias{monty_example}
-\title{Example models for \pkg{monty}}
+\title{Load example models from monty.  These models exist so that we can
+create (hopefully) interesting examples in the documentation
+without them becoming overwhelming.  You should probably not use
+these for anything other than exploring the package.}
 \usage{
 monty_example(name, ...)
 }
 \arguments{
-\item{name}{String giving the model name. One of
-\code{"banana"}, \code{"gaussian"}, \code{"ring"}, \code{"mixture2d"}.}
+\item{name}{Name of the example, as a string.  See Details for
+supported models.}
 
-\item{...}{Additional arguments forwarded to the specific model
-constructor (see sections below for each model’s parameters).}
+\item{...}{Optional parameters that are passed to create the
+model.  All models can be created with no additional parameters,
+but you can tweak their behaviour by passing named parameters
+here.  See Details.}
 }
 \value{
-A \link{monty_model} object with fields \code{parameters},
-\code{density} (log-density), \code{gradient}, \code{direct_sample}
-(where available), and \code{domain}. All returned models set
-\code{properties = monty_model_properties(allow_multiple_parameters = TRUE)}
-so they can be evaluated for parameter matrices.
+A \link{monty_model} object.
 }
 \description{
 Load small, ready-made target distributions for demonstrations, tests,
@@ -28,35 +29,53 @@ overwhelming. All examples contain an analytic gradient and can
 thus be also used to explore gradient-based samplers such as
 \link{monty_sampler_hmc}.
 }
-\details{
-These models are primarily intended for examples, unit tests, and
-teaching materials. They aim to be simple but non‑trivial, and they
-expose analytic gradients when that’s helpful for HMC/NUTS.
+\section{Supported models:}{
+Each model has a \strong{arguments} that are passed through as \code{...} in
+\code{monty_example} and are used to set up the example.  This creates
+a \code{monty_model} object that will accept \strong{parameters}, which are
+the values in the argument \code{parameters} passed to
+\code{monty_model_density}.
+\subsection{\code{banana}}{
+
+The banana model is a two-dimensional banana-shaped function, with
+strong local correlation.  This example was picked because it is
+useful for illustrating the limitations of random-walk proposals.
+The model has two parameters \code{alpha} and \code{beta} and is based on
+two successive draws, one conditional on the other.
+
+You can vary the argument \code{sigma} for this model on creation, the
+default is 0.5
 }
-\section{Supported models}{
 
-\describe{
-\item{\code{"banana"}}{A two-dimensional “banana”-shaped target with
-strong local correlation; useful for illustrating the limitations of
-random-walk proposals. Tunable by \code{sigma}.}
+\subsection{\code{gaussian}}{
 
-\item{\code{"gaussian"}}{A centred multivariate Gaussian \eqn{N(0, \Sigma)}
-with user-supplied variance–covariance matrix \eqn{\Sigma}.}
+A multivariate Gaussian centred at the origin.  Takes a
+variance-covariance-matrix as its argument.  Parameters are
+letters a, b, ... up to the number of dimensions.
+}
 
-\item{\code{"ring"}}{A two-dimensional ring-shaped density whose
-log-density is proportional to \eqn{-(\|x\|-r)^2/(2\,sd^2)}. Includes an
-analytic gradient and a direct sampler in polar coordinates.}
+\subsection{\code{ring}}{
 
-\item{\code{"mixture2d"}}{An equal-weight mixture of \eqn{k} isotropic
-2D Gaussians with standard deviation \code{sd} and centres either
-provided by the user (\code{means}) or drawn uniformly in a square of
-half-width \code{spread}. Includes an analytic gradient.}
+A two-dimensional ring-shaped density whose log-density is
+proportional to $-(\|x\|-r)^2/(2\,sd^2)$.  Includes an analytic
+gradient and a direct sampler in polar coordinates.  The
+constructor takes that arguments \code{r} and \code{sd}, and the parameters
+of the \code{monty_model} are \code{x1} and \code{x2} (corresponding to the two
+dimensions of the polar coordinates).
+}
+
+\subsection{\code{mixture2d}}{
+
+An equal-weight mixture of \code{k} isotropic 2D Gaussians with
+standard deviation \code{sd} and centres either provided by the
+argument (\code{means}) or drawn uniformly in a square of half-width
+\code{spread}. Includes an analytic gradient.
 }
 }
 
 \examples{
 # Banana target
-m1 <- monty_example("banana")                   # default sigma = 0.5
+m1 <- monty_example("banana")
 m2 <- monty_example("banana", sigma = 0.2)
 
 # 2D Gaussian with diagonal covariance
@@ -66,8 +85,7 @@ m3 <- monty_example("gaussian", diag(2))
 m4 <- monty_example("ring", r = 3, sd = 0.25)
 
 # 2D Gaussian mixture with 12 components
-m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4, seed = 42)
-
+m5 <- monty_example("mixture2d", k = 12, sd = 0.35, spread = 4)
 }
 \seealso{
 \link{monty_model}, \link{monty_model_properties}

--- a/man/monty_sampler_parallel_tempering.Rd
+++ b/man/monty_sampler_parallel_tempering.Rd
@@ -79,3 +79,29 @@ with many such peaks and will never mix properly.
 }
 }
 
+\section{Tuning the beta values}{
+The argument \code{beta} controls the spacing of temperature among
+chains.  Ideally, this is set so that adjacent chains all have the
+same probability of swapping, which generally means that the
+\code{beta} values themselves will \emph{not} be equidistant.  Creating the
+appropriate vector of betas (or "annealing schedule") requires
+running a pilot run, then computing new \code{beta} values, then
+running another (new) chain with the new beta values, repeating
+this iteration a few times until the beta values stabilise.
+Rumour has it, this should only take a few iterations.
+
+The updated values of \code{beta} are stored in the \code{details} of your
+samples after running.  So if you have a set of samples called
+\code{s}, then \code{s$details$beta} will contain new beta values that you
+can use on the next run.
+
+It is important not to concatenate chains that are computed with
+different \code{beta} values as they will not generally represent
+samples from the target distribution (as an extreme case, consider
+one set of beta values where we never accept swaps onto the target
+distribution and another where we always do; we obviously cannot
+concatenate these).  Therefore, every time that you change beta
+values you should start a new chain.  You can do this with
+\link{monty_sample_continue} so long as you pass \code{append = FALSE}.
+}
+

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -15,3 +15,84 @@ test_that("can use banana", {
   expect_equal(dim(x2), c(2, 2))
   expect_equal(unname(x2[, 1]), x1)
 })
+
+
+test_that("multiple parameters through the ring are the same as single", {
+  m <- monty_example("ring")
+  xy <- rbind(runif(10), runif(10))
+  expect_identical(m$density(xy), apply(xy, 2, m$density))
+  expect_identical(m$gradient(xy), apply(xy, 2, m$gradient))
+})
+
+
+test_that("gradient calculation is correct at origin", {
+  m <- monty_example("ring")
+  expect_equal(m$gradient(c(0, 0)), c(0, 0))
+
+  ## and for the multiple case:
+  xy <- rbind(runif(10), runif(10))
+  xy[, 4] <- c(0, 0)
+  expect_identical(m$gradient(xy), apply(xy, 2, m$gradient))
+})
+
+
+test_that("gradient calculations agree with empirical estimate", {
+  m <- monty_example("ring", r = 3, sd = 0.5)
+  xy <- rbind(runif(10), runif(10))
+  expect_equal(apply(xy, 2, function(p) numDeriv::grad(m$density, p)),
+               m$gradient(xy))
+})
+
+
+test_that("can directly sample from ring", {
+  ## Actually showing this has the correct distribution is not
+  ## straightforward, though visually it's ok.  Noone should be
+  ## relying on this anyway.
+  r <- monty_rng_create(seed = 1, n_streams = 1)
+  m <- monty_example("ring", r = 10, sd = 1)
+  xy <- m$direct_sample(r)
+  expect_length(xy, 2)
+})
+
+
+test_that("multiple parameters through the mixture are the same as single", {
+  set.seed(1)
+  m <- monty_example("mixture2d", spread = 5)
+  xy <- rbind(runif(10), runif(10))
+  expect_identical(m$density(xy), apply(xy, 2, m$density))
+  expect_identical(m$gradient(xy), apply(xy, 2, m$gradient))
+})
+
+
+test_that("gradient calculations agree with empirical estimate", {
+  set.seed(1)
+  m <- monty_example("mixture2d", spread = 5)
+  xy <- rbind(runif(10), runif(10))
+  expect_equal(apply(xy, 2, function(p) numDeriv::grad(m$density, p)),
+               m$gradient(xy))
+})
+
+
+test_that("can directly sample from mixture", {
+  set.seed(1)
+  ## Actually showing this has the correct distribution is not
+  ## straightforward, though visually it's ok.  Noone should be
+  ## relying on this anyway.
+  r <- monty_rng_create(seed = 1, n_streams = 1)
+  m <- monty_example("mixture2d", spread = 5)
+  xy <- m$direct_sample(r)
+  expect_length(xy, 2)
+})
+
+
+test_that("validate arguments to mixture2d", {
+  expect_error(monty_example("mixture2d"), "spread' must be a scalar")
+  expect_error(monty_example("mixture2d", spread = 1, means = 1),
+               "Do not provide 'spread' if providing 'means'")
+  expect_error(monty_example("mixture2d", means = 1),
+               "Expected 'means' to be a matrix")
+  expect_error(monty_example("mixture2d", means = matrix(0, 3, 3)),
+               "Expected 'means' to have 2 columns")
+  expect_error(monty_example("mixture2d", means = matrix(0, 3, 2)),
+               "Expected 'means' to have 8 rows")
+})

--- a/tests/testthat/test-parallel-tempering.R
+++ b/tests/testthat/test-parallel-tempering.R
@@ -14,6 +14,17 @@ test_that("can run a PT sampler", {
   expect_setequal(names(res$details),
                   c("accept_swap", "attempt_swap", "beta", "sampler"))
   expect_equal(dim(res$details$accept_swap), c(10, 4))
+  expect_equal(dim(res$details$attempt_swap), c(10, 4))
+  expect_true(all(res$details$attempt_swap >= res$details$accept_swap))
+
+  beta <- res$details$beta
+  expect_length(beta, 11)
+  expect_equal(beta[[1]], 1)
+  expect_equal(beta[[11]], 0)
+  expect_true(all(diff(beta) < 0))
+  expect_equal(validate_parallel_tempering_beta(10, beta), beta)
+  expect_equal(which.max(abs(diff(beta))), 1)
+
   expect_null(res$details$sampler)
 })
 

--- a/tests/testthat/test-parallel-tempering.R
+++ b/tests/testthat/test-parallel-tempering.R
@@ -11,7 +11,8 @@ test_that("can run a PT sampler", {
   res <- monty_sample(posterior, sampler, 50, n_chains = 4)
 
   expect_type(res$details, "list")
-  expect_setequal(names(res$details), c("accept_swap", "sampler"))
+  expect_setequal(names(res$details),
+                  c("accept_swap", "attempt_swap", "beta", "sampler"))
   expect_equal(dim(res$details$accept_swap), c(10, 4))
   expect_null(res$details$sampler)
 })
@@ -37,7 +38,8 @@ test_that("can sample with base model", {
   res <- monty_sample(posterior, sampler, 100, n_chains = 4)
 
   expect_type(res$details, "list")
-  expect_setequal(names(res$details), c("accept_swap", "sampler"))
+  expect_setequal(names(res$details),
+                  c("accept_swap", "attempt_swap", "beta", "sampler"))
   expect_equal(dim(res$details$accept_swap), c(10, 4))
   expect_null(res$details$sampler)
 })


### PR DESCRIPTION
An example, though not terribly convincing at present (see below for an update though)

```
## beta = 1 = cold = target or posterior
## beta = 0 = hot = base or prior
set.seed(1)
likelihood <- ex_mixture(5)
n_rungs <- 5
prior <- monty_dsl({
  x ~ Normal(0, 10)
})
posterior <- likelihood + prior
sampler <- monty_sampler_parallel_tempering(
  n_rungs = n_rungs,
  sampler = monty_sampler_random_walk(vcv = matrix(0.1)))
res <- monty_sample(posterior, sampler, 500, n_chains = 4)

sampler2 <- monty_sampler_parallel_tempering(
  beta = res$details$beta,
  sampler = monty_sampler_random_walk(vcv = matrix(0.1)))
res2 <- monty_sample(posterior, sampler2, 500, n_chains = 4)

sampler3 <- monty_sampler_parallel_tempering(
  beta = res2$details$beta,
  sampler = monty_sampler_random_walk(vcv = matrix(0.1)))
res3 <- monty_sample(posterior, sampler2, 500, n_chains = 4)
```

This PR also includes examples from Marc, originally in #171, though nothing in this PR actually uses them at present, but I think Marc had some examples that required these and the beta tuning - Marc perhaps you could add them here?