### PR TITLE
Add stricter test for vcv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/util.R
+++ b/R/util.R
@@ -45,7 +45,7 @@ check_vcv_matrix <- function(vcv, name, call) {
 
 is_positive_definite <- function(x, tol = sqrt(.Machine$double.eps)) {
   ev <- eigen(x, symmetric = TRUE)
-  all(ev$values >= -tol * abs(ev$values[1]))
+  all(ev$values >= -tol * abs(ev$values[1])) && qr(x)$rank == nrow(x)
 }
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -20,6 +20,22 @@ test_that("reject inappropriate vcv matrices", {
 })
 
 
+test_that("reject matrices with very small negative eigenvalues", {
+  m <- matrix(
+    c(3.1036393552184e-05, -3.88403180949637e-05, 3.46531590129688e-06,
+      -2.36852306981765e-05, -3.88403180949637e-05, 4.86064950549581e-05,
+      -4.33664986492722e-06, 2.96407471738945e-05, 3.46531590129688e-06,
+      -4.33664986492722e-06, 3.86913971676197e-07, -2.64453427638987e-06,
+      -2.36852306981765e-05, 2.96407471738945e-05, -2.64453427638987e-06,
+      1.80752364891431e-05),
+    4, 4)
+  ev <- eigen(m, symmetric = TRUE)
+  expect_true(all(ev$values >= -sqrt(.Machine$double.eps) * abs(ev$values[1])))
+  expect_equal(qr(m)$rank, 1)
+  expect_false(is_positive_definite(m))
+})
+
+
 test_that("reject inappropriate vcv arrays", {
   vcv <- array(0, c(2, 2, 5))
   vcv[1, 1, ] <- 1:5


### PR DESCRIPTION
As discussed on Teams, there are some matrices where our eigenvalue check (all eigenvalues are nonzero, to machine precision) but are not suitable for use as a vcv because they are rank deficient.  This would not happen if we had infinite precision, because the rank deficiency requires that an eigenvalue is zero (citation: someone on SO - https://math.stackexchange.com/questions/1524444/connection-between-rank-and-positive-definiteness). 

The example here is a subset of the larger matrix that Keith was working with, which shows the same pathology. It is *very* close to failing the eigenvalue test