### PR TITLE
Ensure monty_sample_continue works with HMC with debug on

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/sampler-hmc.R
+++ b/R/sampler-hmc.R
@@ -365,7 +365,7 @@ hmc_history_recorder <- function(control, pars, history = NULL) {
   } else {
     is_parallel_tempering <- length(dim(history$accept)) > 2
     if (is_parallel_tempering) {
-      env$pars <- as.vector(aperm(history$pars, c(1, 2, 4, 3, 5)))
+      env$pars <- as.vector(aperm(history$pars, c(1, 3, 2, 4, 5)))
       env$accept <- as.vector(history$accept)
     } else {
       env$pars <- as.vector(aperm(history$pars, c(1, 4, 2, 3)))

--- a/tests/testthat/test-parallel-tempering.R
+++ b/tests/testthat/test-parallel-tempering.R
@@ -212,30 +212,9 @@ test_that("can continue a parallel tempering chain using hmc", {
   posterior <- likelihood + prior
   
   set.seed(1)
-  sampler <- monty_sampler_parallel_tempering(
-    n_rungs = 10,
-    sampler = monty_sampler_hmc())
-  res1 <- monty_sample(posterior, sampler, 30, n_chains = 4, restartable = TRUE)
-  res2 <- monty_sample_continue(res1, 70)
-  
-  set.seed(1)
-  sampler <- monty_sampler_parallel_tempering(
-    n_rungs = 10,
-    sampler = monty_sampler_hmc(debug = TRUE))
-  cmp <- monty_sample(posterior, sampler, 100, n_chains = 4)
-  
-  expect_equal(res2$pars, cmp$pars)
-})
-
-
-test_that("can continue a parallel tempering chain using hmc with debug", {
-  likelihood <- ex_mixture(5)
-  prior <- monty_dsl({
-    x ~ Normal(0, 10)
-  })
-  posterior <- likelihood + prior
-  
-  set.seed(1)
+  ## We do this using debug = TRUE in order to test that the sampler details
+  ## are correct. Without debug the results will be the same (just with no
+  ## sampler details) so it's unnecessary to test that as well
   sampler <- monty_sampler_parallel_tempering(
     n_rungs = 10,
     sampler = monty_sampler_hmc(debug = TRUE))
@@ -249,7 +228,7 @@ test_that("can continue a parallel tempering chain using hmc with debug", {
   cmp <- monty_sample(posterior, sampler, 100, n_chains = 4)
   
   expect_equal(res2$pars, cmp$pars)
-  expect_equal(res2$details$sampler$pars[, , , 31:100, ], cmp$details$sampler$pars[, , , 31:100, ])
+  expect_equal(res2$details$sampler$pars, cmp$details$sampler$pars)
   expect_equal(res2$details$sampler$accept, cmp$details$sampler$accept)
 })
 

--- a/tests/testthat/test-parallel-tempering.R
+++ b/tests/testthat/test-parallel-tempering.R
@@ -204,6 +204,56 @@ test_that("can use hmc with parallel tempering", {
 })
 
 
+test_that("can continue a parallel tempering chain using hmc", {
+  likelihood <- ex_mixture(5)
+  prior <- monty_dsl({
+    x ~ Normal(0, 10)
+  })
+  posterior <- likelihood + prior
+  
+  set.seed(1)
+  sampler <- monty_sampler_parallel_tempering(
+    n_rungs = 10,
+    sampler = monty_sampler_hmc())
+  res1 <- monty_sample(posterior, sampler, 30, n_chains = 4, restartable = TRUE)
+  res2 <- monty_sample_continue(res1, 70)
+  
+  set.seed(1)
+  sampler <- monty_sampler_parallel_tempering(
+    n_rungs = 10,
+    sampler = monty_sampler_hmc(debug = TRUE))
+  cmp <- monty_sample(posterior, sampler, 100, n_chains = 4)
+  
+  expect_equal(res2$pars, cmp$pars)
+})
+
+
+test_that("can continue a parallel tempering chain using hmc with debug", {
+  likelihood <- ex_mixture(5)
+  prior <- monty_dsl({
+    x ~ Normal(0, 10)
+  })
+  posterior <- likelihood + prior
+  
+  set.seed(1)
+  sampler <- monty_sampler_parallel_tempering(
+    n_rungs = 10,
+    sampler = monty_sampler_hmc(debug = TRUE))
+  res1 <- monty_sample(posterior, sampler, 30, n_chains = 4, restartable = TRUE)
+  res2 <- monty_sample_continue(res1, 70)
+  
+  set.seed(1)
+  sampler <- monty_sampler_parallel_tempering(
+    n_rungs = 10,
+    sampler = monty_sampler_hmc(debug = TRUE))
+  cmp <- monty_sample(posterior, sampler, 100, n_chains = 4)
+  
+  expect_equal(res2$pars, cmp$pars)
+  expect_equal(res2$details$sampler$pars[, , , 31:100, ], cmp$details$sampler$pars[, , , 31:100, ])
+  expect_equal(res2$details$sampler$accept, cmp$details$sampler$accept)
+})
+
+
 test_that("tempering a model with no gradient produces one with no grad", {
   properties <- monty_model_properties(allow_multiple_parameters = TRUE)
   a <- monty_model(list(parameters = "x",


### PR DESCRIPTION
This fixes an issue where currently `monty_sample_continue` works for HMC if `debug = FALSE` 

```
set.seed(1)

prior <- monty_dsl({
  x1 ~ Normal(0, 2)
  x2 ~ Normal(0, 2)
})

likelihood <- monty_example("mixture2d", k = 10, spread = 5)
posterior <- likelihood + prior

sampler1 <- monty_sampler_parallel_tempering(
  n_rungs = 10,
  sampler = monty_sampler_hmc(),
  base = prior)
res1 <- monty_sample(posterior, sampler1, 500, n_chains = 3, initial = c(0, 0),
                     restartable = TRUE)

res1 <- monty_sample_continue(res1, 1000)
```

but not when `debug = TRUE`
```
sampler2 <- monty_sampler_parallel_tempering(
  n_rungs = 10,
  sampler = monty_sampler_hmc(debug = TRUE),
  base = prior)
res2 <- monty_sample(posterior, sampler2, 500, n_chains = 3, initial = c(0, 0),
                     restartable = TRUE)

res2 <- monty_sample_continue(res2, 1000)
```

which gives the error
```
Error in state_sampler$pars[, , , chain_id, drop = FALSE] : 
  incorrect number of dimensions
9.
sub_state_sampler <- control$sampler$state$restore(
chain_id,
sub_state_chain,
state_sampler$sub_state_sampler, ... at sampler-parallel-tempering.R#326
8.
state_sampler <- sampler$state$restore(
chain_id, state_chain, state$sampler, sampler$control, model) at runner.R#214
7.
monty_continue_chain(i, state, model, sampler, steps, pb$update) at runner.R#43
6.
FUN(X[[i]], ...)
5.
with_progress_fail_on_error(
pb,
lapply(
seq_len(n_chains), ... at runner.R#38
4.
withCallingHandlers(
code,
error = function(e) progress$fail(),
interrupt = function(e) progress$fail()) at progress.R#154
3.
with_progress_fail_on_error(
pb,
lapply(
seq_len(n_chains), ... at runner.R#38
2.
res <- runner$continue(state, model, sampler, steps) at sample.R#201
1.
monty_sample_continue(res2, 1000)
 
```