### PR TITLE
Add missing functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.8
+Version: 0.4.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -496,6 +496,18 @@ T beta(T a, T b) {
 }
 
 template <typename T>
+__host__ __device__
+T lchoose(T n, T k) {
+  return lfactorial(n) - lfactorial(k) - lfactorial(n - k);
+}
+
+template <typename T>
+__host__ __device__
+T choose(T n, T k) {
+  return exp(lchoose(n, k));
+}
+
+template <typename T>
 T fintdiv(T x, T y) {
   return monty::math::floor(x / y);
 }

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -14,15 +14,15 @@ namespace math {
 
 // Automatically generated functions; see scripts/update_monty_math in
 // the monty source repo
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type round(real_type x) {
+T round(T x) {
   return std::round(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type round(int x) {
+  real_type round(int x) {
   return std::round(static_cast<real_type>(x));
 }
 
@@ -34,15 +34,15 @@ inline float round(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type ceil(real_type x) {
+T ceil(T x) {
   return std::ceil(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type ceil(int x) {
+  real_type ceil(int x) {
   return std::ceil(static_cast<real_type>(x));
 }
 
@@ -54,15 +54,15 @@ inline float ceil(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type floor(real_type x) {
+T floor(T x) {
   return std::floor(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type floor(int x) {
+  real_type floor(int x) {
   return std::floor(static_cast<real_type>(x));
 }
 
@@ -74,15 +74,15 @@ inline float floor(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type trunc(real_type x) {
+T trunc(T x) {
   return std::trunc(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type trunc(int x) {
+  real_type trunc(int x) {
   return std::trunc(static_cast<real_type>(x));
 }
 
@@ -94,15 +94,15 @@ inline float trunc(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sqrt(real_type x) {
+T sqrt(T x) {
   return std::sqrt(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type sqrt(int x) {
+  real_type sqrt(int x) {
   return std::sqrt(static_cast<real_type>(x));
 }
 
@@ -114,15 +114,15 @@ inline float sqrt(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type exp(real_type x) {
+T exp(T x) {
   return std::exp(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type exp(int x) {
+  real_type exp(int x) {
   return std::exp(static_cast<real_type>(x));
 }
 
@@ -134,15 +134,15 @@ inline float exp(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type expm1(real_type x) {
+T expm1(T x) {
   return std::expm1(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type expm1(int x) {
+  real_type expm1(int x) {
   return std::expm1(static_cast<real_type>(x));
 }
 
@@ -154,15 +154,15 @@ inline float expm1(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log(real_type x) {
+T log(T x) {
   return std::log(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type log(int x) {
+  real_type log(int x) {
   return std::log(static_cast<real_type>(x));
 }
 
@@ -174,15 +174,15 @@ inline float log(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log2(real_type x) {
+T log2(T x) {
   return std::log2(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type log2(int x) {
+  real_type log2(int x) {
   return std::log2(static_cast<real_type>(x));
 }
 
@@ -194,15 +194,15 @@ inline float log2(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log10(real_type x) {
+T log10(T x) {
   return std::log10(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type log10(int x) {
+  real_type log10(int x) {
   return std::log10(static_cast<real_type>(x));
 }
 
@@ -214,15 +214,15 @@ inline float log10(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log1p(real_type x) {
+T log1p(T x) {
   return std::log1p(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type log1p(int x) {
+  real_type log1p(int x) {
   return std::log1p(static_cast<real_type>(x));
 }
 
@@ -234,15 +234,15 @@ inline float log1p(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type erf(real_type x) {
+T erf(T x) {
   return std::erf(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type erf(int x) {
+  real_type erf(int x) {
   return std::erf(static_cast<real_type>(x));
 }
 
@@ -254,15 +254,15 @@ inline float erf(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type erfc(real_type x) {
+T erfc(T x) {
   return std::erfc(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type erfc(int x) {
+  real_type erfc(int x) {
   return std::erfc(static_cast<real_type>(x));
 }
 
@@ -274,15 +274,15 @@ inline float erfc(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tgamma(real_type x) {
+T tgamma(T x) {
   return std::tgamma(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type tgamma(int x) {
+  real_type tgamma(int x) {
   return std::tgamma(static_cast<real_type>(x));
 }
 
@@ -294,15 +294,15 @@ inline float tgamma(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type cos(real_type x) {
+T cos(T x) {
   return std::cos(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type cos(int x) {
+  real_type cos(int x) {
   return std::cos(static_cast<real_type>(x));
 }
 
@@ -314,15 +314,15 @@ inline float cos(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sin(real_type x) {
+T sin(T x) {
   return std::sin(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type sin(int x) {
+  real_type sin(int x) {
   return std::sin(static_cast<real_type>(x));
 }
 
@@ -334,15 +334,15 @@ inline float sin(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tan(real_type x) {
+T tan(T x) {
   return std::tan(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type tan(int x) {
+  real_type tan(int x) {
   return std::tan(static_cast<real_type>(x));
 }
 
@@ -354,15 +354,15 @@ inline float tan(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type acos(real_type x) {
+T acos(T x) {
   return std::acos(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type acos(int x) {
+  real_type acos(int x) {
   return std::acos(static_cast<real_type>(x));
 }
 
@@ -374,15 +374,15 @@ inline float acos(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type asin(real_type x) {
+T asin(T x) {
   return std::asin(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type asin(int x) {
+  real_type asin(int x) {
   return std::asin(static_cast<real_type>(x));
 }
 
@@ -394,15 +394,15 @@ inline float asin(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type atan(real_type x) {
+T atan(T x) {
   return std::atan(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type atan(int x) {
+  real_type atan(int x) {
   return std::atan(static_cast<real_type>(x));
 }
 
@@ -414,15 +414,15 @@ inline float atan(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type cosh(real_type x) {
+T cosh(T x) {
   return std::cosh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type cosh(int x) {
+  real_type cosh(int x) {
   return std::cosh(static_cast<real_type>(x));
 }
 
@@ -434,15 +434,15 @@ inline float cosh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sinh(real_type x) {
+T sinh(T x) {
   return std::sinh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type sinh(int x) {
+  real_type sinh(int x) {
   return std::sinh(static_cast<real_type>(x));
 }
 
@@ -454,15 +454,15 @@ inline float sinh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tanh(real_type x) {
+T tanh(T x) {
   return std::tanh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type tanh(int x) {
+  real_type tanh(int x) {
   return std::tanh(static_cast<real_type>(x));
 }
 
@@ -474,15 +474,15 @@ inline float tanh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type acosh(real_type x) {
+T acosh(T x) {
   return std::acosh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type acosh(int x) {
+  real_type acosh(int x) {
   return std::acosh(static_cast<real_type>(x));
 }
 
@@ -494,15 +494,15 @@ inline float acosh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type asinh(real_type x) {
+T asinh(T x) {
   return std::asinh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type asinh(int x) {
+  real_type asinh(int x) {
   return std::asinh(static_cast<real_type>(x));
 }
 
@@ -514,15 +514,15 @@ inline float asinh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type atanh(real_type x) {
+T atanh(T x) {
   return std::atanh(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type atanh(int x) {
+  real_type atanh(int x) {
   return std::atanh(static_cast<real_type>(x));
 }
 
@@ -531,26 +531,6 @@ template <>
 __device__
 inline float atanh(float x) {
   return ::atanhf(x);
-}
-#endif
-
-template <typename real_type>
-__host__ __device__
-real_type copysign(real_type x) {
-  return std::copysign(x);
-}
-
-template <typename real_type>
-__host__ __device__
-real_type copysign(int x) {
-  return std::copysign(static_cast<real_type>(x));
-}
-
-#ifdef __CUDA_ARCH__
-template <>
-__device__
-inline float copysign(float x) {
-  return ::copysignf(x);
 }
 #endif
 

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -496,12 +496,6 @@ T lchoose(T x, T y) {
 
 template <typename T>
 __host__ __device__
-T lchoose(T x, T y) {
-  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
-}
-
-template <typename T>
-__host__ __device__
 T choose(T x, T y) {
   return exp(lchoose(x, y));
 }

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -14,9 +14,9 @@ namespace math {
 
 // Automatically generated functions; see scripts/update_monty_math in
 // the monty source repo
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T round(T x) {
+real_type round(real_type x) {
   return std::round(x);
 }
 
@@ -34,9 +34,9 @@ inline float round(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T ceil(T x) {
+real_type ceil(real_type x) {
   return std::ceil(x);
 }
 
@@ -54,9 +54,9 @@ inline float ceil(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T floor(T x) {
+real_type floor(real_type x) {
   return std::floor(x);
 }
 
@@ -74,9 +74,9 @@ inline float floor(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T trunc(T x) {
+real_type trunc(real_type x) {
   return std::trunc(x);
 }
 
@@ -94,9 +94,9 @@ inline float trunc(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sqrt(T x) {
+real_type sqrt(real_type x) {
   return std::sqrt(x);
 }
 
@@ -114,9 +114,9 @@ inline float sqrt(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T exp(T x) {
+real_type exp(real_type x) {
   return std::exp(x);
 }
 
@@ -134,9 +134,9 @@ inline float exp(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T expm1(T x) {
+real_type expm1(real_type x) {
   return std::expm1(x);
 }
 
@@ -154,9 +154,9 @@ inline float expm1(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log(T x) {
+real_type log(real_type x) {
   return std::log(x);
 }
 
@@ -174,9 +174,9 @@ inline float log(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log2(T x) {
+real_type log2(real_type x) {
   return std::log2(x);
 }
 
@@ -194,9 +194,9 @@ inline float log2(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log10(T x) {
+real_type log10(real_type x) {
   return std::log10(x);
 }
 
@@ -214,9 +214,9 @@ inline float log10(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log1p(T x) {
+real_type log1p(real_type x) {
   return std::log1p(x);
 }
 
@@ -234,9 +234,9 @@ inline float log1p(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T erf(T x) {
+real_type erf(real_type x) {
   return std::erf(x);
 }
 
@@ -254,9 +254,9 @@ inline float erf(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T erfc(T x) {
+real_type erfc(real_type x) {
   return std::erfc(x);
 }
 
@@ -274,9 +274,9 @@ inline float erfc(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tgamma(T x) {
+real_type tgamma(real_type x) {
   return std::tgamma(x);
 }
 
@@ -294,9 +294,9 @@ inline float tgamma(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T cos(T x) {
+real_type cos(real_type x) {
   return std::cos(x);
 }
 
@@ -314,9 +314,9 @@ inline float cos(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sin(T x) {
+real_type sin(real_type x) {
   return std::sin(x);
 }
 
@@ -334,9 +334,9 @@ inline float sin(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tan(T x) {
+real_type tan(real_type x) {
   return std::tan(x);
 }
 
@@ -354,9 +354,9 @@ inline float tan(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T acos(T x) {
+real_type acos(real_type x) {
   return std::acos(x);
 }
 
@@ -374,9 +374,9 @@ inline float acos(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T asin(T x) {
+real_type asin(real_type x) {
   return std::asin(x);
 }
 
@@ -394,9 +394,9 @@ inline float asin(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T atan(T x) {
+real_type atan(real_type x) {
   return std::atan(x);
 }
 
@@ -414,9 +414,9 @@ inline float atan(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T cosh(T x) {
+real_type cosh(real_type x) {
   return std::cosh(x);
 }
 
@@ -434,9 +434,9 @@ inline float cosh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sinh(T x) {
+real_type sinh(real_type x) {
   return std::sinh(x);
 }
 
@@ -454,9 +454,9 @@ inline float sinh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tanh(T x) {
+real_type tanh(real_type x) {
   return std::tanh(x);
 }
 
@@ -474,9 +474,9 @@ inline float tanh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T acosh(T x) {
+real_type acosh(real_type x) {
   return std::acosh(x);
 }
 
@@ -494,9 +494,9 @@ inline float acosh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T asinh(T x) {
+real_type asinh(real_type x) {
   return std::asinh(x);
 }
 
@@ -514,9 +514,9 @@ inline float asinh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T atanh(T x) {
+real_type atanh(real_type x) {
   return std::atanh(x);
 }
 
@@ -534,9 +534,9 @@ inline float atanh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T copysign(T x) {
+real_type copysign(real_type x) {
   return std::copysign(x);
 }
 

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -212,6 +212,20 @@ inline float tgamma(float x) {
 
 template <typename T>
 __host__ __device__
+T lgamma(T x) {
+  return std::lgamma(x);
+}
+
+#ifdef __CUDA_ARCH__
+template <>
+__device__
+inline float lgamma(float x) {
+  return ::lgammaf(x);
+}
+#endif
+
+template <typename T>
+__host__ __device__
 T cos(T x) {
   return std::cos(x);
 }
@@ -457,29 +471,16 @@ T max(T a, T b) {
   return a > b ? a : b;
 }
 
-template <typename real_type>
-__host__ __device__ real_type lgamma(real_type x) {
-  static_assert(std::is_floating_point<real_type>::value,
-                "lgamma should only be used with real types");
-  return std::lgamma(x);
-}
-
-#ifdef __CUDA_ARCH__
-template <>
-inline __device__ float lgamma(float x) {
-  return ::lgammaf(x);
-}
-
-template <>
-inline __device__ double lgamma(double x) {
-  return ::lgamma(x);
-}
-#endif
-
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type lfactorial(int x) {
-  return lgamma(static_cast<real_type>(x + 1));
+T lfactorial(T x) {
+  return lgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T factorial(T x) {
+  return tgamma(x + 1);
 }
 
 template <typename T>

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -484,14 +484,14 @@ real_type lfactorial(int x) {
 
 template <typename T>
 __host__ __device__
-T beta(T a, T b) {
-  return exp(lbeta(a, b));
+T lbeta(T a, T b) {
+  return lgamma(a) + lgamma(b) - lgamma(a + b);
 }
 
 template <typename T>
 __host__ __device__
-T lbeta(T a, T b) {
-  return lgamma(a) + lgamma(b) - lgamma(a + b);
+T beta(T a, T b) {
+  return exp(lbeta(a, b));
 }
 
 // We can do this (more efficiently!) with copysign, but end up with
@@ -503,6 +503,28 @@ template <typename T>
 __host__ __device__
 T sign(T x) {
   return (T(0) < x) - (x < T(0));
+}
+
+
+inline double fmodr(double x, double y) {
+  const auto ret = std::fmod(x, y);
+  if (ret * y < 0) {
+    ret += y;
+  }
+  return ret;
+}
+
+inline float fmodr(float x, float y) {
+  const auto ret = std::fmodf(x, y);
+  if (ret * y < 0) {
+    ret += y;
+  }
+  return ret;
+}
+
+template <typename real_type>
+real_type fintdiv(real_type x, real_type y) {
+  return monty::math::floor(x / y);
 }
 
 }

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -476,10 +476,34 @@ inline __device__ double lgamma(double x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type lfactorial(int x) {
+T factorial(T x) {
+  return tgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T lfactorial(T x) {
   return lgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T lchoose(T x, T y) {
+  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
+}
+
+template <typename T>
+__host__ __device__
+T lchoose(T x, T y) {
+  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
+}
+
+template <typename T>
+__host__ __device__
+T choose(T x, T y) {
+  return exp(lchoose(x, y));
 }
 
 template <typename T>

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -482,6 +482,18 @@ real_type lfactorial(int x) {
   return lgamma(static_cast<real_type>(x + 1));
 }
 
+template <typename T>
+__host__ __device__
+T beta(T a, T b) {
+  return exp(lbeta(a, b));
+}
+
+template <typename T>
+__host__ __device__
+T lbeta(T a, T b) {
+  return lgamma(a) + lgamma(b) - lgamma(a + b);
+}
+
 // We can do this (more efficiently!) with copysign, but end up with
 // having a bit of fight with different overloads.  This way is fine.
 //

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -476,28 +476,10 @@ inline __device__ double lgamma(double x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T factorial(T x) {
-  return tgamma(x + 1);
-}
-
-template <typename T>
-__host__ __device__
-T lfactorial(T x) {
-  return lgamma(x + 1);
-}
-
-template <typename T>
-__host__ __device__
-T lchoose(T x, T y) {
-  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
-}
-
-template <typename T>
-__host__ __device__
-T choose(T x, T y) {
-  return exp(lchoose(x, y));
+real_type lfactorial(int x) {
+  return lgamma(static_cast<real_type>(x + 1));
 }
 
 template <typename T>

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -505,27 +505,5 @@ T sign(T x) {
   return (T(0) < x) - (x < T(0));
 }
 
-
-inline double fmodr(double x, double y) {
-  const auto ret = std::fmod(x, y);
-  if (ret * y < 0) {
-    ret += y;
-  }
-  return ret;
-}
-
-inline float fmodr(float x, float y) {
-  const auto ret = std::fmodf(x, y);
-  if (ret * y < 0) {
-    ret += y;
-  }
-  return ret;
-}
-
-template <typename real_type>
-real_type fintdiv(real_type x, real_type y) {
-  return monty::math::floor(x / y);
-}
-
 }
 }

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -495,6 +495,11 @@ T beta(T a, T b) {
   return exp(lbeta(a, b));
 }
 
+template <typename T>
+T fintdiv(T x, T y) {
+  return monty::math::floor(x / y);
+}
+
 // We can do this (more efficiently!) with copysign, but end up with
 // having a bit of fight with different overloads.  This way is fine.
 //

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -170,6 +170,48 @@ inline float log1p(float x) {
 
 template <typename T>
 __host__ __device__
+T erf(T x) {
+  return std::erf(x);
+}
+
+#ifdef __CUDA_ARCH__
+template <>
+__device__
+inline float erf(float x) {
+  return ::erff(x);
+}
+#endif
+
+template <typename T>
+__host__ __device__
+T erfc(T x) {
+  return std::erfc(x);
+}
+
+#ifdef __CUDA_ARCH__
+template <>
+__device__
+inline float erfc(float x) {
+  return ::erfcf(x);
+}
+#endif
+
+template <typename T>
+__host__ __device__
+T tgamma(T x) {
+  return std::tgamma(x);
+}
+
+#ifdef __CUDA_ARCH__
+template <>
+__device__
+inline float tgamma(float x) {
+  return ::tgammaf(x);
+}
+#endif
+
+template <typename T>
+__host__ __device__
 T cos(T x) {
   return std::cos(x);
 }

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -22,7 +22,7 @@ real_type round(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type round(int x) {
+real_type round(int x) {
   return std::round(static_cast<real_type>(x));
 }
 
@@ -42,7 +42,7 @@ real_type ceil(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type ceil(int x) {
+real_type ceil(int x) {
   return std::ceil(static_cast<real_type>(x));
 }
 
@@ -62,7 +62,7 @@ real_type floor(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type floor(int x) {
+real_type floor(int x) {
   return std::floor(static_cast<real_type>(x));
 }
 
@@ -82,7 +82,7 @@ real_type trunc(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type trunc(int x) {
+real_type trunc(int x) {
   return std::trunc(static_cast<real_type>(x));
 }
 
@@ -102,7 +102,7 @@ real_type sqrt(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type sqrt(int x) {
+real_type sqrt(int x) {
   return std::sqrt(static_cast<real_type>(x));
 }
 
@@ -122,7 +122,7 @@ real_type exp(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type exp(int x) {
+real_type exp(int x) {
   return std::exp(static_cast<real_type>(x));
 }
 
@@ -142,7 +142,7 @@ real_type expm1(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type expm1(int x) {
+real_type expm1(int x) {
   return std::expm1(static_cast<real_type>(x));
 }
 
@@ -162,7 +162,7 @@ real_type log(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type log(int x) {
+real_type log(int x) {
   return std::log(static_cast<real_type>(x));
 }
 
@@ -182,7 +182,7 @@ real_type log2(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type log2(int x) {
+real_type log2(int x) {
   return std::log2(static_cast<real_type>(x));
 }
 
@@ -202,7 +202,7 @@ real_type log10(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type log10(int x) {
+real_type log10(int x) {
   return std::log10(static_cast<real_type>(x));
 }
 
@@ -222,7 +222,7 @@ real_type log1p(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type log1p(int x) {
+real_type log1p(int x) {
   return std::log1p(static_cast<real_type>(x));
 }
 
@@ -242,7 +242,7 @@ real_type erf(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type erf(int x) {
+real_type erf(int x) {
   return std::erf(static_cast<real_type>(x));
 }
 
@@ -262,7 +262,7 @@ real_type erfc(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type erfc(int x) {
+real_type erfc(int x) {
   return std::erfc(static_cast<real_type>(x));
 }
 
@@ -282,7 +282,7 @@ real_type tgamma(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type tgamma(int x) {
+real_type tgamma(int x) {
   return std::tgamma(static_cast<real_type>(x));
 }
 
@@ -302,7 +302,7 @@ real_type cos(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type cos(int x) {
+real_type cos(int x) {
   return std::cos(static_cast<real_type>(x));
 }
 
@@ -322,7 +322,7 @@ real_type sin(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type sin(int x) {
+real_type sin(int x) {
   return std::sin(static_cast<real_type>(x));
 }
 
@@ -342,7 +342,7 @@ real_type tan(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type tan(int x) {
+real_type tan(int x) {
   return std::tan(static_cast<real_type>(x));
 }
 
@@ -362,7 +362,7 @@ real_type acos(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type acos(int x) {
+real_type acos(int x) {
   return std::acos(static_cast<real_type>(x));
 }
 
@@ -382,7 +382,7 @@ real_type asin(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type asin(int x) {
+real_type asin(int x) {
   return std::asin(static_cast<real_type>(x));
 }
 
@@ -402,7 +402,7 @@ real_type atan(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type atan(int x) {
+real_type atan(int x) {
   return std::atan(static_cast<real_type>(x));
 }
 
@@ -422,7 +422,7 @@ real_type cosh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type cosh(int x) {
+real_type cosh(int x) {
   return std::cosh(static_cast<real_type>(x));
 }
 
@@ -442,7 +442,7 @@ real_type sinh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type sinh(int x) {
+real_type sinh(int x) {
   return std::sinh(static_cast<real_type>(x));
 }
 
@@ -462,7 +462,7 @@ real_type tanh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type tanh(int x) {
+real_type tanh(int x) {
   return std::tanh(static_cast<real_type>(x));
 }
 
@@ -482,7 +482,7 @@ real_type acosh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type acosh(int x) {
+real_type acosh(int x) {
   return std::acosh(static_cast<real_type>(x));
 }
 
@@ -502,7 +502,7 @@ real_type asinh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type asinh(int x) {
+real_type asinh(int x) {
   return std::asinh(static_cast<real_type>(x));
 }
 
@@ -522,7 +522,7 @@ real_type atanh(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type atanh(int x) {
+real_type atanh(int x) {
   return std::atanh(static_cast<real_type>(x));
 }
 
@@ -542,7 +542,7 @@ real_type copysign(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type copysign(int x) {
+real_type copysign(int x) {
   return std::copysign(static_cast<real_type>(x));
 }
 

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -20,9 +20,10 @@ T round(T x) {
   return std::round(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double round(int x) {
-  return std::round(static_cast<double>(x));
+  real_type round(int x) {
+  return std::round(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -39,9 +40,10 @@ T ceil(T x) {
   return std::ceil(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double ceil(int x) {
-  return std::ceil(static_cast<double>(x));
+  real_type ceil(int x) {
+  return std::ceil(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -58,9 +60,10 @@ T floor(T x) {
   return std::floor(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double floor(int x) {
-  return std::floor(static_cast<double>(x));
+  real_type floor(int x) {
+  return std::floor(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -77,9 +80,10 @@ T trunc(T x) {
   return std::trunc(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double trunc(int x) {
-  return std::trunc(static_cast<double>(x));
+  real_type trunc(int x) {
+  return std::trunc(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -96,9 +100,10 @@ T sqrt(T x) {
   return std::sqrt(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double sqrt(int x) {
-  return std::sqrt(static_cast<double>(x));
+  real_type sqrt(int x) {
+  return std::sqrt(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -115,9 +120,10 @@ T exp(T x) {
   return std::exp(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double exp(int x) {
-  return std::exp(static_cast<double>(x));
+  real_type exp(int x) {
+  return std::exp(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -134,9 +140,10 @@ T expm1(T x) {
   return std::expm1(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double expm1(int x) {
-  return std::expm1(static_cast<double>(x));
+  real_type expm1(int x) {
+  return std::expm1(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -153,9 +160,10 @@ T log(T x) {
   return std::log(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double log(int x) {
-  return std::log(static_cast<double>(x));
+  real_type log(int x) {
+  return std::log(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -172,9 +180,10 @@ T log2(T x) {
   return std::log2(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double log2(int x) {
-  return std::log2(static_cast<double>(x));
+  real_type log2(int x) {
+  return std::log2(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -191,9 +200,10 @@ T log10(T x) {
   return std::log10(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double log10(int x) {
-  return std::log10(static_cast<double>(x));
+  real_type log10(int x) {
+  return std::log10(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -210,9 +220,10 @@ T log1p(T x) {
   return std::log1p(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double log1p(int x) {
-  return std::log1p(static_cast<double>(x));
+  real_type log1p(int x) {
+  return std::log1p(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -229,9 +240,10 @@ T erf(T x) {
   return std::erf(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double erf(int x) {
-  return std::erf(static_cast<double>(x));
+  real_type erf(int x) {
+  return std::erf(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -248,9 +260,10 @@ T erfc(T x) {
   return std::erfc(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double erfc(int x) {
-  return std::erfc(static_cast<double>(x));
+  real_type erfc(int x) {
+  return std::erfc(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -267,9 +280,10 @@ T tgamma(T x) {
   return std::tgamma(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double tgamma(int x) {
-  return std::tgamma(static_cast<double>(x));
+  real_type tgamma(int x) {
+  return std::tgamma(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -286,9 +300,10 @@ T cos(T x) {
   return std::cos(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double cos(int x) {
-  return std::cos(static_cast<double>(x));
+  real_type cos(int x) {
+  return std::cos(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -305,9 +320,10 @@ T sin(T x) {
   return std::sin(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double sin(int x) {
-  return std::sin(static_cast<double>(x));
+  real_type sin(int x) {
+  return std::sin(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -324,9 +340,10 @@ T tan(T x) {
   return std::tan(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double tan(int x) {
-  return std::tan(static_cast<double>(x));
+  real_type tan(int x) {
+  return std::tan(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -343,9 +360,10 @@ T acos(T x) {
   return std::acos(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double acos(int x) {
-  return std::acos(static_cast<double>(x));
+  real_type acos(int x) {
+  return std::acos(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -362,9 +380,10 @@ T asin(T x) {
   return std::asin(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double asin(int x) {
-  return std::asin(static_cast<double>(x));
+  real_type asin(int x) {
+  return std::asin(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -381,9 +400,10 @@ T atan(T x) {
   return std::atan(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double atan(int x) {
-  return std::atan(static_cast<double>(x));
+  real_type atan(int x) {
+  return std::atan(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -400,9 +420,10 @@ T cosh(T x) {
   return std::cosh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double cosh(int x) {
-  return std::cosh(static_cast<double>(x));
+  real_type cosh(int x) {
+  return std::cosh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -419,9 +440,10 @@ T sinh(T x) {
   return std::sinh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double sinh(int x) {
-  return std::sinh(static_cast<double>(x));
+  real_type sinh(int x) {
+  return std::sinh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -438,9 +460,10 @@ T tanh(T x) {
   return std::tanh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double tanh(int x) {
-  return std::tanh(static_cast<double>(x));
+  real_type tanh(int x) {
+  return std::tanh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -457,9 +480,10 @@ T acosh(T x) {
   return std::acosh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double acosh(int x) {
-  return std::acosh(static_cast<double>(x));
+  real_type acosh(int x) {
+  return std::acosh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -476,9 +500,10 @@ T asinh(T x) {
   return std::asinh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double asinh(int x) {
-  return std::asinh(static_cast<double>(x));
+  real_type asinh(int x) {
+  return std::asinh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -495,9 +520,10 @@ T atanh(T x) {
   return std::atanh(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double atanh(int x) {
-  return std::atanh(static_cast<double>(x));
+  real_type atanh(int x) {
+  return std::atanh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -514,9 +540,10 @@ T copysign(T x) {
   return std::copysign(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double copysign(int x) {
-  return std::copysign(static_cast<double>(x));
+  real_type copysign(int x) {
+  return std::copysign(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -14,9 +14,9 @@ namespace math {
 
 // Automatically generated functions; see scripts/update_monty_math in
 // the monty source repo
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T round(T x) {
+real_type round(real_type x) {
   return std::round(x);
 }
 
@@ -34,9 +34,9 @@ inline float round(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T ceil(T x) {
+real_type ceil(real_type x) {
   return std::ceil(x);
 }
 
@@ -54,9 +54,9 @@ inline float ceil(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T floor(T x) {
+real_type floor(real_type x) {
   return std::floor(x);
 }
 
@@ -74,9 +74,9 @@ inline float floor(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T trunc(T x) {
+real_type trunc(real_type x) {
   return std::trunc(x);
 }
 
@@ -94,9 +94,9 @@ inline float trunc(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sqrt(T x) {
+real_type sqrt(real_type x) {
   return std::sqrt(x);
 }
 
@@ -114,9 +114,9 @@ inline float sqrt(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T exp(T x) {
+real_type exp(real_type x) {
   return std::exp(x);
 }
 
@@ -134,9 +134,9 @@ inline float exp(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T expm1(T x) {
+real_type expm1(real_type x) {
   return std::expm1(x);
 }
 
@@ -154,9 +154,9 @@ inline float expm1(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log(T x) {
+real_type log(real_type x) {
   return std::log(x);
 }
 
@@ -174,9 +174,9 @@ inline float log(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log2(T x) {
+real_type log2(real_type x) {
   return std::log2(x);
 }
 
@@ -194,9 +194,9 @@ inline float log2(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log10(T x) {
+real_type log10(real_type x) {
   return std::log10(x);
 }
 
@@ -214,9 +214,9 @@ inline float log10(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T log1p(T x) {
+real_type log1p(real_type x) {
   return std::log1p(x);
 }
 
@@ -234,9 +234,9 @@ inline float log1p(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T erf(T x) {
+real_type erf(real_type x) {
   return std::erf(x);
 }
 
@@ -254,9 +254,9 @@ inline float erf(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T erfc(T x) {
+real_type erfc(real_type x) {
   return std::erfc(x);
 }
 
@@ -274,9 +274,9 @@ inline float erfc(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tgamma(T x) {
+real_type tgamma(real_type x) {
   return std::tgamma(x);
 }
 
@@ -294,9 +294,9 @@ inline float tgamma(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T cos(T x) {
+real_type cos(real_type x) {
   return std::cos(x);
 }
 
@@ -314,9 +314,9 @@ inline float cos(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sin(T x) {
+real_type sin(real_type x) {
   return std::sin(x);
 }
 
@@ -334,9 +334,9 @@ inline float sin(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tan(T x) {
+real_type tan(real_type x) {
   return std::tan(x);
 }
 
@@ -354,9 +354,9 @@ inline float tan(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T acos(T x) {
+real_type acos(real_type x) {
   return std::acos(x);
 }
 
@@ -374,9 +374,9 @@ inline float acos(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T asin(T x) {
+real_type asin(real_type x) {
   return std::asin(x);
 }
 
@@ -394,9 +394,9 @@ inline float asin(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T atan(T x) {
+real_type atan(real_type x) {
   return std::atan(x);
 }
 
@@ -414,9 +414,9 @@ inline float atan(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T cosh(T x) {
+real_type cosh(real_type x) {
   return std::cosh(x);
 }
 
@@ -434,9 +434,9 @@ inline float cosh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T sinh(T x) {
+real_type sinh(real_type x) {
   return std::sinh(x);
 }
 
@@ -454,9 +454,9 @@ inline float sinh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T tanh(T x) {
+real_type tanh(real_type x) {
   return std::tanh(x);
 }
 
@@ -474,9 +474,9 @@ inline float tanh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T acosh(T x) {
+real_type acosh(real_type x) {
   return std::acosh(x);
 }
 
@@ -494,9 +494,9 @@ inline float acosh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T asinh(T x) {
+real_type asinh(real_type x) {
   return std::asinh(x);
 }
 
@@ -514,9 +514,9 @@ inline float asinh(float x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T atanh(T x) {
+real_type atanh(real_type x) {
   return std::atanh(x);
 }
 

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -20,6 +20,11 @@ T round(T x) {
   return std::round(x);
 }
 
+__host__ __device__
+  double round(int x) {
+  return std::round(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -32,6 +37,11 @@ template <typename T>
 __host__ __device__
 T ceil(T x) {
   return std::ceil(x);
+}
+
+__host__ __device__
+  double ceil(int x) {
+  return std::ceil(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -48,6 +58,11 @@ T floor(T x) {
   return std::floor(x);
 }
 
+__host__ __device__
+  double floor(int x) {
+  return std::floor(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -60,6 +75,11 @@ template <typename T>
 __host__ __device__
 T trunc(T x) {
   return std::trunc(x);
+}
+
+__host__ __device__
+  double trunc(int x) {
+  return std::trunc(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -76,6 +96,11 @@ T sqrt(T x) {
   return std::sqrt(x);
 }
 
+__host__ __device__
+  double sqrt(int x) {
+  return std::sqrt(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -88,6 +113,11 @@ template <typename T>
 __host__ __device__
 T exp(T x) {
   return std::exp(x);
+}
+
+__host__ __device__
+  double exp(int x) {
+  return std::exp(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -104,6 +134,11 @@ T expm1(T x) {
   return std::expm1(x);
 }
 
+__host__ __device__
+  double expm1(int x) {
+  return std::expm1(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -116,6 +151,11 @@ template <typename T>
 __host__ __device__
 T log(T x) {
   return std::log(x);
+}
+
+__host__ __device__
+  double log(int x) {
+  return std::log(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -132,6 +172,11 @@ T log2(T x) {
   return std::log2(x);
 }
 
+__host__ __device__
+  double log2(int x) {
+  return std::log2(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -144,6 +189,11 @@ template <typename T>
 __host__ __device__
 T log10(T x) {
   return std::log10(x);
+}
+
+__host__ __device__
+  double log10(int x) {
+  return std::log10(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -160,6 +210,11 @@ T log1p(T x) {
   return std::log1p(x);
 }
 
+__host__ __device__
+  double log1p(int x) {
+  return std::log1p(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -172,6 +227,11 @@ template <typename T>
 __host__ __device__
 T erf(T x) {
   return std::erf(x);
+}
+
+__host__ __device__
+  double erf(int x) {
+  return std::erf(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -188,6 +248,11 @@ T erfc(T x) {
   return std::erfc(x);
 }
 
+__host__ __device__
+  double erfc(int x) {
+  return std::erfc(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -200,6 +265,11 @@ template <typename T>
 __host__ __device__
 T tgamma(T x) {
   return std::tgamma(x);
+}
+
+__host__ __device__
+  double tgamma(int x) {
+  return std::tgamma(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -216,6 +286,11 @@ T cos(T x) {
   return std::cos(x);
 }
 
+__host__ __device__
+  double cos(int x) {
+  return std::cos(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -228,6 +303,11 @@ template <typename T>
 __host__ __device__
 T sin(T x) {
   return std::sin(x);
+}
+
+__host__ __device__
+  double sin(int x) {
+  return std::sin(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -244,6 +324,11 @@ T tan(T x) {
   return std::tan(x);
 }
 
+__host__ __device__
+  double tan(int x) {
+  return std::tan(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -256,6 +341,11 @@ template <typename T>
 __host__ __device__
 T acos(T x) {
   return std::acos(x);
+}
+
+__host__ __device__
+  double acos(int x) {
+  return std::acos(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -272,6 +362,11 @@ T asin(T x) {
   return std::asin(x);
 }
 
+__host__ __device__
+  double asin(int x) {
+  return std::asin(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -284,6 +379,11 @@ template <typename T>
 __host__ __device__
 T atan(T x) {
   return std::atan(x);
+}
+
+__host__ __device__
+  double atan(int x) {
+  return std::atan(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -300,6 +400,11 @@ T cosh(T x) {
   return std::cosh(x);
 }
 
+__host__ __device__
+  double cosh(int x) {
+  return std::cosh(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -312,6 +417,11 @@ template <typename T>
 __host__ __device__
 T sinh(T x) {
   return std::sinh(x);
+}
+
+__host__ __device__
+  double sinh(int x) {
+  return std::sinh(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -328,6 +438,11 @@ T tanh(T x) {
   return std::tanh(x);
 }
 
+__host__ __device__
+  double tanh(int x) {
+  return std::tanh(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -340,6 +455,11 @@ template <typename T>
 __host__ __device__
 T acosh(T x) {
   return std::acosh(x);
+}
+
+__host__ __device__
+  double acosh(int x) {
+  return std::acosh(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -356,6 +476,11 @@ T asinh(T x) {
   return std::asinh(x);
 }
 
+__host__ __device__
+  double asinh(int x) {
+  return std::asinh(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -370,6 +495,11 @@ T atanh(T x) {
   return std::atanh(x);
 }
 
+__host__ __device__
+  double atanh(int x) {
+  return std::atanh(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__
@@ -382,6 +512,11 @@ template <typename T>
 __host__ __device__
 T copysign(T x) {
   return std::copysign(x);
+}
+
+__host__ __device__
+  double copysign(int x) {
+  return std::copysign(static_cast<double>(x));
 }
 
 #ifdef __CUDA_ARCH__

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -479,7 +479,7 @@ inline __device__ double lgamma(double x) {
 template <typename real_type>
 __host__ __device__
 real_type lfactorial(int x) {
-  return lgamma(static_cast<real_type>(x + 1));
+  return lgamma(x + 1);
 }
 
 template <typename T>

--- a/inst/include/monty/random/math.hpp
+++ b/inst/include/monty/random/math.hpp
@@ -14,16 +14,10 @@ namespace math {
 
 // Automatically generated functions; see scripts/update_monty_math in
 // the monty source repo
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type round(real_type x) {
+T round(T x) {
   return std::round(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type round(int x) {
-  return std::round(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -34,16 +28,10 @@ inline float round(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type ceil(real_type x) {
+T ceil(T x) {
   return std::ceil(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type ceil(int x) {
-  return std::ceil(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -54,16 +42,10 @@ inline float ceil(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type floor(real_type x) {
+T floor(T x) {
   return std::floor(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type floor(int x) {
-  return std::floor(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -74,16 +56,10 @@ inline float floor(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type trunc(real_type x) {
+T trunc(T x) {
   return std::trunc(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type trunc(int x) {
-  return std::trunc(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -94,16 +70,10 @@ inline float trunc(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sqrt(real_type x) {
+T sqrt(T x) {
   return std::sqrt(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type sqrt(int x) {
-  return std::sqrt(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -114,16 +84,10 @@ inline float sqrt(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type exp(real_type x) {
+T exp(T x) {
   return std::exp(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type exp(int x) {
-  return std::exp(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -134,16 +98,10 @@ inline float exp(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type expm1(real_type x) {
+T expm1(T x) {
   return std::expm1(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type expm1(int x) {
-  return std::expm1(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -154,16 +112,10 @@ inline float expm1(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log(real_type x) {
+T log(T x) {
   return std::log(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type log(int x) {
-  return std::log(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -174,16 +126,10 @@ inline float log(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log2(real_type x) {
+T log2(T x) {
   return std::log2(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type log2(int x) {
-  return std::log2(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -194,16 +140,10 @@ inline float log2(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log10(real_type x) {
+T log10(T x) {
   return std::log10(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type log10(int x) {
-  return std::log10(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -214,16 +154,10 @@ inline float log10(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type log1p(real_type x) {
+T log1p(T x) {
   return std::log1p(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type log1p(int x) {
-  return std::log1p(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -234,16 +168,10 @@ inline float log1p(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type erf(real_type x) {
+T erf(T x) {
   return std::erf(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type erf(int x) {
-  return std::erf(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -254,16 +182,10 @@ inline float erf(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type erfc(real_type x) {
+T erfc(T x) {
   return std::erfc(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type erfc(int x) {
-  return std::erfc(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -274,16 +196,10 @@ inline float erfc(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tgamma(real_type x) {
+T tgamma(T x) {
   return std::tgamma(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type tgamma(int x) {
-  return std::tgamma(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -294,16 +210,10 @@ inline float tgamma(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type cos(real_type x) {
+T cos(T x) {
   return std::cos(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type cos(int x) {
-  return std::cos(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -314,16 +224,10 @@ inline float cos(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sin(real_type x) {
+T sin(T x) {
   return std::sin(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type sin(int x) {
-  return std::sin(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -334,16 +238,10 @@ inline float sin(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tan(real_type x) {
+T tan(T x) {
   return std::tan(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type tan(int x) {
-  return std::tan(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -354,16 +252,10 @@ inline float tan(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type acos(real_type x) {
+T acos(T x) {
   return std::acos(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type acos(int x) {
-  return std::acos(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -374,16 +266,10 @@ inline float acos(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type asin(real_type x) {
+T asin(T x) {
   return std::asin(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type asin(int x) {
-  return std::asin(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -394,16 +280,10 @@ inline float asin(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type atan(real_type x) {
+T atan(T x) {
   return std::atan(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type atan(int x) {
-  return std::atan(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -414,16 +294,10 @@ inline float atan(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type cosh(real_type x) {
+T cosh(T x) {
   return std::cosh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type cosh(int x) {
-  return std::cosh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -434,16 +308,10 @@ inline float cosh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type sinh(real_type x) {
+T sinh(T x) {
   return std::sinh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type sinh(int x) {
-  return std::sinh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -454,16 +322,10 @@ inline float sinh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type tanh(real_type x) {
+T tanh(T x) {
   return std::tanh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type tanh(int x) {
-  return std::tanh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -474,16 +336,10 @@ inline float tanh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type acosh(real_type x) {
+T acosh(T x) {
   return std::acosh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type acosh(int x) {
-  return std::acosh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -494,16 +350,10 @@ inline float acosh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type asinh(real_type x) {
+T asinh(T x) {
   return std::asinh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type asinh(int x) {
-  return std::asinh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -514,16 +364,10 @@ inline float asinh(float x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type atanh(real_type x) {
+T atanh(T x) {
   return std::atanh(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type atanh(int x) {
-  return std::atanh(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__
@@ -531,6 +375,20 @@ template <>
 __device__
 inline float atanh(float x) {
   return ::atanhf(x);
+}
+#endif
+
+template <typename T>
+__host__ __device__
+T copysign(T x) {
+  return std::copysign(x);
+}
+
+#ifdef __CUDA_ARCH__
+template <>
+__device__
+inline float copysign(float x) {
+  return ::copysignf(x);
 }
 #endif
 

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -86,10 +86,34 @@ inline __device__ double lgamma(double x) {
 }
 #endif
 
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type lfactorial(int x) {
+T factorial(T x) {
+  return tgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T lfactorial(T x) {
   return lgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T lchoose(T x, T y) {
+  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
+}
+
+template <typename T>
+__host__ __device__
+T lchoose(T x, T y) {
+  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
+}
+
+template <typename T>
+__host__ __device__
+T choose(T x, T y) {
+  return exp(lchoose(x, y));
 }
 
 template <typename T>

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -94,14 +94,14 @@ real_type lfactorial(int x) {
 
 template <typename T>
 __host__ __device__
-T beta(T a, T b) {
-  return exp(lbeta(a, b));
+T lbeta(T a, T b) {
+  return lgamma(a) + lgamma(b) - lgamma(a + b);
 }
 
 template <typename T>
 __host__ __device__
-T lbeta(T a, T b) {
-  return lgamma(a) + lgamma(b) - lgamma(a + b);
+T beta(T a, T b) {
+  return exp(lbeta(a, b));
 }
 
 // We can do this (more efficiently!) with copysign, but end up with

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -92,6 +92,18 @@ T beta(T a, T b) {
 }
 
 template <typename T>
+__host__ __device__
+T lchoose(T n, T k) {
+  return lfactorial(n) - lfactorial(k) - lfactorial(n - k);
+}
+
+template <typename T>
+__host__ __device__
+T choose(T n, T k) {
+  return exp(lchoose(n, k));
+}
+
+template <typename T>
 T fintdiv(T x, T y) {
   return monty::math::floor(x / y);
 }

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -92,6 +92,18 @@ real_type lfactorial(int x) {
   return lgamma(static_cast<real_type>(x + 1));
 }
 
+template <typename T>
+__host__ __device__
+T beta(T a, T b) {
+  return exp(lbeta(a, b));
+}
+
+template <typename T>
+__host__ __device__
+T lbeta(T a, T b) {
+  return lgamma(a) + lgamma(b) - lgamma(a + b);
+}
+
 // We can do this (more efficiently!) with copysign, but end up with
 // having a bit of fight with different overloads.  This way is fine.
 //

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -67,29 +67,16 @@ T max(T a, T b) {
   return a > b ? a : b;
 }
 
-template <typename real_type>
-__host__ __device__ real_type lgamma(real_type x) {
-  static_assert(std::is_floating_point<real_type>::value,
-                "lgamma should only be used with real types");
-  return std::lgamma(x);
-}
-
-#ifdef __CUDA_ARCH__
-template <>
-inline __device__ float lgamma(float x) {
-  return ::lgammaf(x);
-}
-
-template <>
-inline __device__ double lgamma(double x) {
-  return ::lgamma(x);
-}
-#endif
-
-template <typename real_type>
+template <typename T>
 __host__ __device__
-real_type lfactorial(int x) {
-  return lgamma(static_cast<real_type>(x + 1));
+T lfactorial(T x) {
+  return lgamma(x + 1);
+}
+
+template <typename T>
+__host__ __device__
+T factorial(T x) {
+  return tgamma(x + 1);
 }
 
 template <typename T>

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -106,12 +106,6 @@ T lchoose(T x, T y) {
 
 template <typename T>
 __host__ __device__
-T lchoose(T x, T y) {
-  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
-}
-
-template <typename T>
-__host__ __device__
 T choose(T x, T y) {
   return exp(lchoose(x, y));
 }

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -89,7 +89,7 @@ inline __device__ double lgamma(double x) {
 template <typename real_type>
 __host__ __device__
 real_type lfactorial(int x) {
-  return lgamma(static_cast<real_type>(x + 1));
+  return lgamma(x + 1);
 }
 
 template <typename T>

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -133,27 +133,5 @@ T sign(T x) {
   return (T(0) < x) - (x < T(0));
 }
 
-
-inline double fmodr(double x, double y) {
-  const auto ret = std::fmod(x, y);
-  if (ret * y < 0) {
-    ret += y;
-  }
-  return ret;
-}
-
-inline float fmodr(float x, float y) {
-  const auto ret = std::fmodf(x, y);
-  if (ret * y < 0) {
-    ret += y;
-  }
-  return ret;
-}
-
-template <typename real_type>
-real_type fintdiv(real_type x, real_type y) {
-  return monty::math::floor(x / y);
-}
-
 }
 }

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -86,28 +86,10 @@ inline __device__ double lgamma(double x) {
 }
 #endif
 
-template <typename T>
+template <typename real_type>
 __host__ __device__
-T factorial(T x) {
-  return tgamma(x + 1);
-}
-
-template <typename T>
-__host__ __device__
-T lfactorial(T x) {
-  return lgamma(x + 1);
-}
-
-template <typename T>
-__host__ __device__
-T lchoose(T x, T y) {
-  return lfactorial(x) - lfactorial(y) - lfactorial(x - y);
-}
-
-template <typename T>
-__host__ __device__
-T choose(T x, T y) {
-  return exp(lchoose(x, y));
+real_type lfactorial(int x) {
+  return lgamma(static_cast<real_type>(x + 1));
 }
 
 template <typename T>

--- a/inst/template/math.hpp
+++ b/inst/template/math.hpp
@@ -91,6 +91,11 @@ T beta(T a, T b) {
   return exp(lbeta(a, b));
 }
 
+template <typename T>
+T fintdiv(T x, T y) {
+  return monty::math::floor(x / y);
+}
+
 // We can do this (more efficiently!) with copysign, but end up with
 // having a bit of fight with different overloads.  This way is fine.
 //

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -11,9 +11,9 @@ fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "acosh", "asinh", "atanh")
 fn2 <- c("atan2")
 
-template1 <- "template <typename T>
+template1 <- "template <typename real_type>
 __host__ __device__
-T {{name}}(T x) {
+real_type {{name}}(real_type x) {
   return std::{{name}}(x);
 }
 

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -20,7 +20,7 @@ real_type {{name}}(real_type x) {
 
 template <typename real_type>
 __host__ __device__
-  real_type {{name}}(int x) {
+real_type {{name}}(int x) {
   return std::{{name}}(static_cast<real_type>(x));
 }
 

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -8,19 +8,14 @@ fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "cos", "sin", "tan",
          "acos", "asin", "atan",
          "cosh", "sinh", "tanh",
-         "acosh", "asinh", "atanh")
+         "acosh", "asinh", "atanh",
+         "copysign")
 fn2 <- c("atan2")
 
-template1 <- "template <typename real_type>
+template1 <- "template <typename T>
 __host__ __device__
-real_type {{name}}(real_type x) {
+T {{name}}(T x) {
   return std::{{name}}(x);
-}
-
-template <typename real_type>
-__host__ __device__
-  real_type {{name}}(int x) {
-  return std::{{name}}(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -18,6 +18,11 @@ T {{name}}(T x) {
   return std::{{name}}(x);
 }
 
+__host__ __device__
+  double {{name}}(int x) {
+  return std::{{name}}(static_cast<double>(x));
+}
+
 #ifdef __CUDA_ARCH__
 template <>
 __device__

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -4,6 +4,7 @@
 ## TODO: tgamma?
 fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "exp", "expm1", "log", "log2", "log10", "log1p",
+         "erf", "erfc", "tgamma",
          "cos", "sin", "tan",
          "acos", "asin", "atan",
          "cosh", "sinh", "tanh",

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -12,9 +12,9 @@ fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "copysign")
 fn2 <- c("atan2")
 
-template1 <- "template <typename T>
+template1 <- "template <typename real_type>
 __host__ __device__
-T {{name}}(T x) {
+real_type {{name}}(real_type x) {
   return std::{{name}}(x);
 }
 

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -41,7 +41,7 @@ inline float {{name}}(float x, float y) {
 #endif"
 
 glue_whisker <- function(template, data) {
-  glue::glue(template, .envir = data, .open = "{{", .close = "}}",
+  glue::glue(template, .envir = as.environment(data), .open = "{{", .close = "}}",
              .trim = FALSE)
 }
 

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -8,19 +8,18 @@ fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "cos", "sin", "tan",
          "acos", "asin", "atan",
          "cosh", "sinh", "tanh",
-         "acosh", "asinh", "atanh",
-         "copysign")
+         "acosh", "asinh", "atanh")
 fn2 <- c("atan2")
 
-template1 <- "template <typename real_type>
+template1 <- "template <typename T>
 __host__ __device__
-real_type {{name}}(real_type x) {
+T {{name}}(T x) {
   return std::{{name}}(x);
 }
 
 template <typename real_type>
 __host__ __device__
-real_type {{name}}(int x) {
+  real_type {{name}}(int x) {
   return std::{{name}}(static_cast<real_type>(x));
 }
 

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -4,7 +4,7 @@
 ## TODO: tgamma?
 fn1 <- c("round", "ceil", "floor", "trunc", "sqrt",
          "exp", "expm1", "log", "log2", "log10", "log1p",
-         "erf", "erfc", "tgamma",
+         "erf", "erfc", "tgamma", "lgamma",
          "cos", "sin", "tan",
          "acos", "asin", "atan",
          "cosh", "sinh", "tanh",

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -41,8 +41,8 @@ inline float {{name}}(float x, float y) {
 #endif"
 
 glue_whisker <- function(template, data) {
-  glue::glue(template, .envir = as.environment(data), .open = "{{", .close = "}}",
-             .trim = FALSE)
+  glue::glue(template, .envir = as.environment(data), .open = "{{",
+             .close = "}}", .trim = FALSE)
 }
 
 code <- c(

--- a/scripts/update_monty_math
+++ b/scripts/update_monty_math
@@ -18,9 +18,10 @@ T {{name}}(T x) {
   return std::{{name}}(x);
 }
 
+template <typename real_type>
 __host__ __device__
-  double {{name}}(int x) {
-  return std::{{name}}(static_cast<double>(x));
+  real_type {{name}}(int x) {
+  return std::{{name}}(static_cast<real_type>(x));
 }
 
 #ifdef __CUDA_ARCH__


### PR DESCRIPTION
Adding `tgamma`, `lbeta`, `beta`, `erf`, `erfc`, `lfactorial` and `factorial`

No standard `lbeta`, `beta`, `lfactorial` or `factorial` C++ functions so I've just defined those in terms of `lgamma` functions