### PR TITLE
DSL array fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.10
+Version: 0.4.11
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/dsl-generate.R
+++ b/R/dsl-generate.R
@@ -127,7 +127,7 @@ dsl_generate_assignment <- function(expr, dest, meta) {
 
   
   if (!is.null(array)) {
-    expr <- dsl_generate_array_loops(expr, array)
+    expr <- dsl_generate_array_loops(expr, array, meta)
   }
   expr
 }
@@ -148,7 +148,7 @@ dsl_generate_density_stochastic <- function(expr, meta) {
                        dsl_generate_density_rewrite_lookup(rhs, "pars", meta))
     
   if (!is.null(array)) {
-    expr <- dsl_generate_array_loops(expr, array)
+    expr <- dsl_generate_array_loops(expr, array, meta)
   }
   expr
 }
@@ -167,7 +167,7 @@ dsl_generate_sample_stochastic <- function(expr, meta) {
   expr <- rlang::call2("<-", lhs, rhs)
   
   if (!is.null(array)) {
-    expr <- dsl_generate_array_loops(expr, array)
+    expr <- dsl_generate_array_loops(expr, array, meta)
   }
   expr
 }
@@ -192,14 +192,15 @@ dsl_generate_density_rewrite_lookup <- function(expr, dest, meta) {
 }
 
 
-dsl_generate_array_loops <- function(expr, array) {
+dsl_generate_array_loops <- function(expr, array, meta) {
   for (x in rev(array)) {
     if (x$type == "range") {
       range <- call("seq", x$from, x$to)
+      range <- dsl_generate_density_rewrite_lookup(range, "pars", meta)
       expr <- call("for", as.symbol(x$name), range, call("{", expr))
     } else { # type is "single"
       idx <- list()
-      idx[[x$name]] <- x$at
+      idx[[x$name]] <- dsl_generate_density_rewrite_lookup(x$at, "pars", meta)
       expr <- substitute_(expr, idx)
     }
   }
@@ -236,9 +237,9 @@ dsl_generate_domain <- function(dat, meta, packer) {
   }
   for (e in dat$exprs) {
     if (e$type == "assignment") {
-      dsl_generate_domain_assignment(e, env, dat$arrays)
+      dsl_generate_domain_assignment(e, env, dat$fixed, dat$arrays)
     } else { # type is "stochastic"
-      domain <- dsl_generate_domain_stochastic(domain, e, env)
+      domain <- dsl_generate_domain_stochastic(domain, e, env, dat$fixed)
     }
   }
   
@@ -252,7 +253,7 @@ dsl_generate_domain <- function(dat, meta, packer) {
 }
 
 
-dsl_generate_domain_assignment <- function(expr, env, arrays) {
+dsl_generate_domain_assignment <- function(expr, env, fixed, arrays) {
   if (is.null(expr$lhs$array)) {
     env[[expr$lhs$name]] <- dsl_static_eval(expr$rhs$expr, env) 
   } else {
@@ -263,7 +264,7 @@ dsl_generate_domain_assignment <- function(expr, env, arrays) {
     }
     array <- expr$lhs$array
     
-    idx <- generate_index_grid(array)
+    idx <- generate_index_grid(array, fixed)
     for (i in seq_len(nrow(idx))) {
       rhs <- substitute_(expr$rhs$expr, as.list(idx[i, , drop = FALSE]))
       rhs_val <- dsl_static_eval(rhs, env)
@@ -273,7 +274,7 @@ dsl_generate_domain_assignment <- function(expr, env, arrays) {
 }
 
 
-dsl_generate_domain_stochastic <- function(domain, expr, env) {
+dsl_generate_domain_stochastic <- function(domain, expr, env, fixed) {
   distr <- expr$rhs$distribution
   
   if (is.null(expr$lhs$array)) {
@@ -283,8 +284,8 @@ dsl_generate_domain_stochastic <- function(domain, expr, env) {
     
     idx <- list()
     for (x in array) {
-      from <- x$from %||% x$at
-      to <- x$to  %||% x$at
+      from <- eval(x$from %||% x$at, fixed)
+      to <- eval(x$to  %||% x$at, fixed)
       idx[[x$name]] <- seq(from = from, to = to)
     }
     idx <- expand.grid(rev(idx))
@@ -327,11 +328,11 @@ fold_c <- function(x) {
 }
 
 
-generate_index_grid <- function(array) {
+generate_index_grid <- function(array, fixed) {
   idx <- list()
   for (x in array) {
-    from <- x$from %||% x$at
-    to <- x$to  %||% x$at
+    from <- eval(x$from %||% x$at, fixed)
+    to <- eval(x$to  %||% x$at, fixed)
     idx[[x$name]] <- seq(from = from, to = to)
   }
   idx <- expand.grid(rev(idx))

--- a/R/dsl-parse-array.R
+++ b/R/dsl-parse-array.R
@@ -6,7 +6,7 @@ dsl_parse_arrays <- function(exprs, fixed, call) {
   check_duplicate_dims(arrays, exprs, call)
   arrays <- resolve_array_references(arrays)
   arrays <- resolve_split_dependencies(arrays, call)
-  arrays <- finalise_arrays_table(arrays, exprs, call)
+  arrays <- finalise_arrays_table(arrays, exprs[is_dim], call)
   
   arrays
 }

--- a/R/dsl-parse.R
+++ b/R/dsl-parse.R
@@ -411,7 +411,7 @@ dsl_parse_check_system <- function(exprs, arrays, fixed, call) {
   special <- vcapply(exprs, function(x) x$special %||% "")
   is_dim <- special == "dim"
   
-  exprs <- dsl_parse_check_system_arrays(exprs, arrays, is_dim, call)
+  exprs <- dsl_parse_check_system_arrays(exprs, fixed, arrays, is_dim, call)
   dsl_parse_check_duplicates(exprs, arrays, call)
   dsl_parse_check_fixed(exprs, fixed, call)
   dsl_parse_check_usage(exprs, fixed, call)
@@ -420,7 +420,7 @@ dsl_parse_check_system <- function(exprs, arrays, fixed, call) {
 }
 
 
-dsl_parse_check_system_arrays <- function(exprs, arrays, is_dim, call) {
+dsl_parse_check_system_arrays <- function(exprs, fixed, arrays, is_dim, call) {
   dim_nms <- arrays$name
   ## First, look for any array calls that do not have a corresponding
   ## dim()
@@ -482,8 +482,8 @@ dsl_parse_check_system_arrays <- function(exprs, arrays, is_dim, call) {
    ## Can now eject the dim equations
   exprs <- exprs[!is_dim]
   
-  dsl_parse_check_system_array_bounds(exprs, arrays, call)
-  dsl_parse_check_system_array_usage(exprs, arrays, call)
+  dsl_parse_check_system_array_bounds(exprs, fixed, arrays, call)
+  dsl_parse_check_system_array_usage(exprs, fixed, arrays, call)
   
   exprs
 }
@@ -612,7 +612,7 @@ dsl_parse_check_consistent_dimensions_expr <- function(expr, src,
 }
 
 
-dsl_parse_check_system_array_bounds <- function(exprs, arrays, call) {
+dsl_parse_check_system_array_bounds <- function(exprs, fixed, arrays, call) {
   
   name <- lapply(exprs, function(x) x$lhs$name)
   
@@ -620,20 +620,26 @@ dsl_parse_check_system_array_bounds <- function(exprs, arrays, call) {
     dims <- unlist(arrays$dims[arrays$name == nm], recursive = FALSE)
     
     i <- nm == name
-    lapply(exprs[i], dsl_parse_check_system_array_bounds_lhs, dims, call)
+    lapply(exprs[i], dsl_parse_check_system_array_bounds_lhs, fixed, dims, call)
     
     i <- vlapply(exprs, function(x) nm %in% x$rhs$depends)
-    lapply(exprs[i], dsl_parse_check_system_array_bounds_rhs, nm, dims, call)
+    lapply(exprs[i], dsl_parse_check_system_array_bounds_rhs, 
+           fixed, nm, dims, call)
   }
   
 }
 
 
-dsl_parse_check_system_array_bounds_lhs <- function(expr, dims, call) {
+dsl_parse_check_system_array_bounds_lhs <- function(expr, fixed, dims, call) {
   name <- expr$lhs$name
   
-  max_index <- lapply(expr$lhs$array, 
-                      function(x) max(x$from %||% x$at, x$to %||% x$at))
+  eval_max_index <- function (x) {
+    from <- eval(x$from %||% x$at, fixed)
+    to <- eval(x$to %||% x$at, fixed)
+    max(from, to)
+  }
+  
+  max_index <- lapply(expr$lhs$array, eval_max_index)
   
   for (i in seq_along(max_index)) {
     if (max_index[[i]] > dims[[i]]) {
@@ -647,15 +653,16 @@ dsl_parse_check_system_array_bounds_lhs <- function(expr, dims, call) {
 }
 
 
-dsl_parse_check_system_array_bounds_rhs <- function(expr, nm, dims, call) {
+dsl_parse_check_system_array_bounds_rhs <- function(expr, fixed, nm, 
+                                                    dims, call) {
   array <- expr$lhs$array
-  index <- generate_index_grid(expr$lhs$array)
+  index <- generate_index_grid(expr$lhs$array, fixed)
   
   check_expr <- function(e) {
     if (is.recursive(e)) {
       if (rlang::is_call(e, "[")) {
         if (deparse(e[[2]]) == nm) {
-          idx <- lapply(rlang::call_args(e)[-1], eval, index)
+          idx <- lapply(rlang::call_args(e)[-1], eval, c(index, fixed))
           for (i in seq_along(idx)) {
             for (j in seq_along(idx[[i]])) {
               if (idx[[i]][j] > dims[[i]] || idx[[i]][j] < 1) {
@@ -682,7 +689,7 @@ dsl_parse_check_system_array_bounds_rhs <- function(expr, nm, dims, call) {
 }
 
 
-dsl_parse_check_system_array_usage <- function(exprs, arrays, call) {
+dsl_parse_check_system_array_usage <- function(exprs, fixed, arrays, call) {
   name <- lapply(exprs, function(x) x$lhs$name)
   type <- lapply(exprs, "[[", "type")
   
@@ -696,7 +703,8 @@ dsl_parse_check_system_array_usage <- function(exprs, arrays, call) {
       idx_expected <- expand.grid(rev(idx_expected))
       idx_expected <- idx_expected[, rev(names(idx_expected)), drop = FALSE]
       
-      idx <- lapply(exprs[i], function(x) generate_index_grid(x$lhs$array))
+      idx <- lapply(exprs[i], 
+                    function(x) generate_index_grid(x$lhs$array, fixed))
       
       for (j in seq_len(nrow(idx_expected))) {
         is_covered <- 

--- a/tests/testthat/test-dsl.R
+++ b/tests/testthat/test-dsl.R
@@ -252,9 +252,9 @@ test_that("can use arrays in dsl", {
   expect_warning(
     m2 <- monty_dsl({
       lambda[1:2] <- 2 * i
-      lambda[3] <- 2 * i + 1
+      lambda[n] <- 2 * i + 1
       x[1] ~ Exponential(lambda[i])
-      x[2:3] ~ Exponential(lambda[i]^2)
+      x[2:n] ~ Exponential(lambda[i]^2)
       dim(x, lambda) <- n
     }, fixed = list(n = 3)),
     "Not creating a gradient function for this model")


### PR DESCRIPTION
Currently this throws an (uninformative) error

```
fixed = list(n_beta = 5)
m <- monty_dsl({
  beta[1] ~ Exponential(mean = 0.3)
  beta[2:n_beta] ~ Exponential(mean = beta[i - 1])
  dim(beta) <- n_beta
}, fixed = fixed)
```

this is due to the usage of the fixed parameter `n_beta` in indexing on the LHS. The fixes here now allow this.      