### PR TITLE
Add save_full_chains option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.11
+Version: 0.4.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Description: Experimental sources for the next generation of mcstate,
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 URL: https://mrc-ide.github.io/monty, https://github.com/mrc-ide/monty
 BugReports: https://github.com/mrc-ide/monty/issues
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Description: Experimental sources for the next generation of mcstate,
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 URL: https://mrc-ide.github.io/monty, https://github.com/mrc-ide/monty
 BugReports: https://github.com/mrc-ide/monty/issues
 Imports:
@@ -41,3 +40,4 @@ Suggests:
 Config/testthat/edition: 3
 Language: en-GB
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -149,9 +149,10 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
   pars <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
   density <- matrix(NA_real_, n_steps_record, n_chains)
   if (save_full_chains) {
-    pars_full <- array(NA_real_, c(n_pars, n_steps, n_chains))
+    full_chains <- list(pars = array(NA_real_, c(n_pars, n_steps, n_chains)),
+                        density = matrix(NA_real_, n_steps, n_chains))
   } else {
-    pars_full <- NULL
+    full_chains <- NULL
   }
   
   
@@ -168,7 +169,8 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
       j <- j + 1L
     }
     if (save_full_chains) {
-      pars_full[, i, ] <- chain_state$pars
+      full_chains$pars[, i, ] <- chain_state$pars
+      full_chains$density[i, ] <- chain_state$density
     }
     progress(chain_id, i)
   }
@@ -176,7 +178,7 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
   ## Pop the parameter names on last
   rownames(pars) <- model$parameters
   if (save_full_chains) {
-    rownames(pars_full) <- model$parameters
+    rownames(full_chains$pars) <- model$parameters
   }
   
   sampler_state <- sampler$state$dump(sampler_state)
@@ -197,5 +199,6 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
 
   ## Normally, we construct samples elsewhere, but it's least weird
   ## for now do do it here.
-  monty_samples(pars, pars_full, density, initial, details, observations, state)
+  monty_samples(pars, density, initial, details,
+                observations, state, full_chains)
 }

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -139,34 +139,46 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
   initial <- chain_state$pars
   n_pars <- length(model$parameters)
   n_chains <- length(chain_state$density)
-  n_steps_record <- steps$total
+  
+  burnin <- steps$burnin
+  thinning_factor <- steps$thinning_factor
+  n_steps <- steps$total
+  n_steps_record <- ceiling((steps$total - burnin) / thinning_factor)
   save_full_chains <- steps$save_full_chains
   
   pars <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
+  density <- matrix(NA_real_, n_steps_record, n_chains)
   if (save_full_chains) {
-    pars_full <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
+    pars_full <- array(NA_real_, c(n_pars, n_steps, n_chains))
   } else {
     pars_full <- NULL
   }
-  density <- matrix(NA_real_, n_steps_record, n_chains)
-
+  
+  
   chain_id <- seq_len(n_chains)
 
-  for (i in seq_len(steps$total)) {
+  j <- 1L
+  for (i in seq_len(n_steps)) {
     chain_state <- sampler$step(chain_state, sampler_state, sampler$control,
                                 model, rng)
-    pars[, i, ] <- chain_state$pars
+    if (i > burnin && i %% thinning_factor == 0) {
+      pars[, j, ] <- chain_state$pars
+      density[j, ] <- chain_state$density
+      ## TODO: also allow observations here if enabled
+      j <- j + 1L
+    }
     if (save_full_chains) {
       pars_full[, i, ] <- chain_state$pars
     }
-    density[i, ] <- chain_state$density
-    ## TODO: also allow observations here if enabled
     progress(chain_id, i)
   }
 
   ## Pop the parameter names on last
   rownames(pars) <- model$parameters
-
+  if (save_full_chains) {
+    rownames(pars_full) <- model$parameters
+  }
+  
   sampler_state <- sampler$state$dump(sampler_state)
   details <- sampler$state$details(sampler_state)
 

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -140,8 +140,14 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
   n_pars <- length(model$parameters)
   n_chains <- length(chain_state$density)
   n_steps_record <- steps$total
-
+  save_full_chains <- steps$save_full_chains
+  
   pars <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
+  if (save_full_chains) {
+    pars_full <- array(NA_real_, c(n_pars, n_steps_record, n_chains))
+  } else {
+    pars_full <- NULL
+  }
   density <- matrix(NA_real_, n_steps_record, n_chains)
 
   chain_id <- seq_len(n_chains)
@@ -150,6 +156,9 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
     chain_state <- sampler$step(chain_state, sampler_state, sampler$control,
                                 model, rng)
     pars[, i, ] <- chain_state$pars
+    if (save_full_chains) {
+      pars_full[, i, ] <- chain_state$pars
+    }
     density[i, ] <- chain_state$density
     ## TODO: also allow observations here if enabled
     progress(chain_id, i)
@@ -176,5 +185,5 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
 
   ## Normally, we construct samples elsewhere, but it's least weird
   ## for now do do it here.
-  monty_samples(pars, density, initial, details, observations, state)
+  monty_samples(pars, pars_full, density, initial, details, observations, state)
 }

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -196,6 +196,11 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
     sampler = sampler_state,
     rng = matrix(monty_rng_state(rng), ncol = n_chains),
     model_rng = model_rng)
+  
+  if (save_full_chains) {
+    full_chains <- monty_samples(full_chains$pars, full_chains$density, initial,
+                                 NULL, NULL, NULL, NULL)
+  }
 
   ## Normally, we construct samples elsewhere, but it's least weird
   ## for now do do it here.

--- a/R/runner-simultaneous.R
+++ b/R/runner-simultaneous.R
@@ -198,8 +198,7 @@ monty_run_chains_simultaneous2 <- function(chain_state, sampler_state,
     model_rng = model_rng)
   
   if (save_full_chains) {
-    full_chains <- monty_samples(full_chains$pars, full_chains$density, initial,
-                                 NULL, NULL, NULL, NULL)
+    full_chains <- monty_samples(full_chains$pars, full_chains$density, initial)
   }
 
   ## Normally, we construct samples elsewhere, but it's least weird

--- a/R/runner.R
+++ b/R/runner.R
@@ -251,7 +251,7 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
       j <- j + 1L
     }
     if (save_full_chains) {
-      history_pars_full[, j] <- chain_state$pars
+      history_pars_full[, i] <- chain_state$pars
     }
     progress(chain_id, i)
   }

--- a/R/runner.R
+++ b/R/runner.R
@@ -235,9 +235,13 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
   history_density <- rep(NA_real_, n_steps_record)
   history_observation <-
     if (has_observer) vector("list", n_steps_record) else NULL
-  history_pars_full <- 
-    if (save_full_chains) matrix(NA_real_, n_pars, n_steps) else NULL
-
+  if (save_full_chains) {
+    history_full_chains <- list(pars = matrix(NA_real_, n_pars, n_steps),
+                                density = rep(NA_real_, n_steps))
+  } else {
+    history_full_chains <- NULL
+  }
+  
   j <- 1L
   for (i in seq_len(n_steps)) {
     chain_state <- sampler$step(chain_state, sampler_state, sampler$control,
@@ -251,7 +255,8 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
       j <- j + 1L
     }
     if (save_full_chains) {
-      history_pars_full[, i] <- chain_state$pars
+      history_full_chains$pars[, i] <- chain_state$pars
+      history_full_chains$density[i] <- chain_state$density
     }
     progress(chain_id, i)
   }
@@ -259,7 +264,7 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
   ## Pop the parameter names on last
   rownames(history_pars) <- model$parameters
   if (save_full_chains) {
-    rownames(history_pars_full) <- model$parameters    
+    rownames(history_full_chains$pars) <- model$parameters    
   }
 
   if (has_observer) {
@@ -274,9 +279,9 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
   ## might hold things like start and stop times here in future.
   history <- list(
     pars = history_pars,
-    pars_full = history_pars_full,
     density = history_density,
-    observations = history_observation)
+    observations = history_observation,
+    full_chains = history_full_chains)
   state <- list(
     chain = chain_state,
     rng = monty_rng_state(rng),

--- a/R/runner.R
+++ b/R/runner.R
@@ -229,11 +229,14 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
   thinning_factor <- steps$thinning_factor
   n_steps <- steps$total
   n_steps_record <- ceiling((steps$total - burnin) / thinning_factor)
+  save_full_chains <- steps$save_full_chains
 
   history_pars <- matrix(NA_real_, n_pars, n_steps_record)
   history_density <- rep(NA_real_, n_steps_record)
   history_observation <-
     if (has_observer) vector("list", n_steps_record) else NULL
+  history_pars_full <- 
+    if (save_full_chains) matrix(NA_real_, n_pars, n_steps) else NULL
 
   j <- 1L
   for (i in seq_len(n_steps)) {
@@ -247,11 +250,17 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
       }
       j <- j + 1L
     }
+    if (save_full_chains) {
+      history_pars_full[, j] <- chain_state$pars
+    }
     progress(chain_id, i)
   }
 
   ## Pop the parameter names on last
   rownames(history_pars) <- model$parameters
+  if (save_full_chains) {
+    rownames(history_pars_full) <- model$parameters    
+  }
 
   if (has_observer) {
     history_observation <- model$observer$finalise(history_observation)
@@ -265,6 +274,7 @@ monty_run_chain2 <- function(chain_id, chain_state, sampler_state, model,
   ## might hold things like start and stop times here in future.
   history <- list(
     pars = history_pars,
+    pars_full = history_pars_full,
     density = history_density,
     observations = history_observation)
   state <- list(

--- a/R/sample-manual.R
+++ b/R/sample-manual.R
@@ -60,10 +60,12 @@
 ##' monty_sample_manual_cleanup(path)
 monty_sample_manual_prepare <- function(model, sampler, n_steps, path,
                                         initial = NULL, n_chains = 1L,
-                                        burnin = NULL, thinning_factor = NULL) {
+                                        burnin = NULL, thinning_factor = NULL,
+                                        save_full_chains = FALSE) {
   ## This break exists to hide the 'seed' argument from the public
   ## interface.  We will use this from the callr version though.
-  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor,
+                              save_full_chains)
   sample_manual_prepare(model, sampler, steps, path, initial, n_chains)
 }
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -207,6 +207,7 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
 
   burnin <- NULL
   thinning_factor <- samples$restart$thinning_factor
+  save_full_chains <- !is.null(samples$pars_full)
   steps <- monty_sample_steps(n_steps, burnin, thinning_factor,
                               save_full_chains)
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -134,8 +134,7 @@ monty_sample <- function(model, sampler, n_steps, initial = NULL,
   res <- runner$run(pars, model, sampler, steps, rng)
 
   observer <- if (model$properties$has_observer) model$observer else NULL
-  samples <- combine_chains(res, sampler, observer, restartable,
-                            save_full_chains)
+  samples <- combine_chains(res, sampler, observer, restartable)
 
   if (restartable) {
     samples$restart <- list(model = model,
@@ -198,7 +197,8 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
 
   burnin <- NULL
   thinning_factor <- samples$restart$thinning_factor
-  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor,
+                              save_full_chains)
 
   res <- runner$continue(state, model, sampler, steps)
   observer <- if (model$properties$has_observer) model$observer else NULL
@@ -342,8 +342,7 @@ initial_parameters <- function(initial, model, rng, call = NULL) {
 }
 
 
-combine_chains <- function(res, sampler, observer, include_state,
-                           save_full_chains) {
+combine_chains <- function(res, sampler, observer, include_state) {
   ## If we used the simultaneous sampler, we've already constructed
   ## something useful here.
   if (inherits(res, "monty_samples")) {
@@ -358,12 +357,12 @@ combine_chains <- function(res, sampler, observer, include_state,
   ## First, process the core history:
   history <- lapply(res, "[[", "history")
   pars <- array_bind(arrays = lapply(history, "[[", "pars"), after = 2)
-  if (save_full_chains) {
+  if (!is.null(history[[1]]$pars_full)) {
     pars_full <- 
       array_bind(arrays = lapply(history, "[[", "pars_full"), after = 2)
   } else {
     pars_full <- NULL
-  }
+  } 
   density <- array_bind(arrays = lapply(history, "[[", "density"), after = 1)
   if (is.null(observer)) {
     observations <- NULL
@@ -406,7 +405,14 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
   } else {
     observations <- observer$append(prev$observations, curr$observations)
   }
+  if (!is.null(prev$pars_full) && !is.null(curr$pars_full)) {
+    pars_full <- array_bind(prev$pars_full, curr$pars_full, on = 2)
+  } else {
+    pars_full <- NULL
+  }
+  
   samples <- list(pars = array_bind(prev$pars, curr$pars, on = 2),
+                  pars_full = pars_full,
                   density = array_bind(prev$density, curr$density, on = 1),
                   initial = prev$initial,
                   details = curr$details,

--- a/R/sample.R
+++ b/R/sample.R
@@ -82,10 +82,6 @@
 ##'   rows will be named with the names of the parameters, from your
 ##'   model.
 ##'
-##' * `pars_full`: If `save_full_chains = TRUE`, an array representing `pars`
-##'   without discarding the burnin and thinning. If `save_full_chains = FALSE`,
-##'   this will be `NULL`.
-##'
 ##' * `density`: A matrix of model log densities, with `n_steps` rows
 ##'   and `n_chains` columns.
 ##'
@@ -100,6 +96,10 @@
 ##'
 ##' * `observations`: Additional details reported by the model.  This
 ##'   one is also subject to change.
+##'
+##' * `full-chains`: If `save_full_chains = TRUE`, an list containing `pars`
+##'   and `density` without discarding the burnin and thinning.
+##'   If `save_full_chains = FALSE`, this will be `NULL`.
 ##'
 ##' @export
 ##' @examples

--- a/R/sample.R
+++ b/R/sample.R
@@ -62,6 +62,12 @@
 ##'   `thinning_factor` is 10, then `n_steps` must be a multiple of
 ##'   10.  This ensures that the last step is in the sample.  The
 ##'   thinning factor cannot be changed when continuing a chain.
+##'   
+##' @param save_full_chains Logical, indicating whether or not the full chains
+##'   of the parameters (without discarding the burnin and thinning) should
+##'   additionally be saved. This is useful if you are thinning to reduce the
+##'   size of observations but still want to retain the full chains of the
+##'   parameters for evaluation purposes.
 ##'
 ##' @return A list of parameters and densities.  We provide conversion
 ##'   to formats used by other packages, notably
@@ -75,6 +81,10 @@
 ##'   `i`th parameter from the `j`th sample from the `k`th chain.  The
 ##'   rows will be named with the names of the parameters, from your
 ##'   model.
+##'
+##' * `pars_full`: If `save_full_chains = TRUE`, an array representing `pars`
+##'   without discarding the burnin and thinning. If `save_full_chains = FALSE`,
+##'   this will be `NULL`.
 ##'
 ##' * `density`: A matrix of model log densities, with `n_steps` rows
 ##'   and `n_chains` columns.

--- a/R/sample.R
+++ b/R/sample.R
@@ -480,6 +480,7 @@ monty_sample_steps <- function(n_steps, burnin = NULL, thinning_factor = NULL,
         call = call)
     }
   }
+  assert_logical(save_full_chains)
   ret <- list(total = n_steps,
               burnin = burnin,
               thinning_factor = thinning_factor,

--- a/R/sample.R
+++ b/R/sample.R
@@ -112,7 +112,7 @@
 monty_sample <- function(model, sampler, n_steps, initial = NULL,
                          n_chains = 1L, runner = NULL,
                          restartable = FALSE, burnin = NULL,
-                         thinning_factor = NULL) {
+                         thinning_factor = NULL, save_full_chains = FALSE) {
   assert_is(model, "monty_model")
   assert_is(sampler, "monty_sampler")
   if (is.null(runner)) {
@@ -128,12 +128,14 @@ monty_sample <- function(model, sampler, n_steps, initial = NULL,
 
   rng <- initial_rng(n_chains)
   pars <- initial_parameters(initial, model, rng, environment())
-  steps <- monty_sample_steps(n_steps, burnin, thinning_factor)
+  steps <- monty_sample_steps(n_steps, burnin, thinning_factor,
+                              save_full_chains)
 
   res <- runner$run(pars, model, sampler, steps, rng)
 
   observer <- if (model$properties$has_observer) model$observer else NULL
-  samples <- combine_chains(res, sampler, observer, restartable)
+  samples <- combine_chains(res, sampler, observer, restartable,
+                            save_full_chains)
 
   if (restartable) {
     samples$restart <- list(model = model,
@@ -340,7 +342,8 @@ initial_parameters <- function(initial, model, rng, call = NULL) {
 }
 
 
-combine_chains <- function(res, sampler, observer, include_state) {
+combine_chains <- function(res, sampler, observer, include_state,
+                           save_full_chains) {
   ## If we used the simultaneous sampler, we've already constructed
   ## something useful here.
   if (inherits(res, "monty_samples")) {
@@ -355,6 +358,12 @@ combine_chains <- function(res, sampler, observer, include_state) {
   ## First, process the core history:
   history <- lapply(res, "[[", "history")
   pars <- array_bind(arrays = lapply(history, "[[", "pars"), after = 2)
+  if (save_full_chains) {
+    pars_full <- 
+      array_bind(arrays = lapply(history, "[[", "pars_full"), after = 2)
+  } else {
+    pars_full <- NULL
+  }
   density <- array_bind(arrays = lapply(history, "[[", "density"), after = 1)
   if (is.null(observer)) {
     observations <- NULL
@@ -387,7 +396,7 @@ combine_chains <- function(res, sampler, observer, include_state) {
     state <- NULL
   }
 
-  monty_samples(pars, density, initial, details, observations, state)
+  monty_samples(pars, pars_full, density, initial, details, observations, state)
 }
 
 
@@ -430,6 +439,7 @@ direct_sample_within_domain <- function(model, rng, max_attempts = 100) {
 
 
 monty_sample_steps <- function(n_steps, burnin = NULL, thinning_factor = NULL,
+                               save_full_chains = FALSE,
                                call = parent.frame()) {
   if (inherits(n_steps, "monty_sample_steps")) {
     return(n_steps)
@@ -456,7 +466,8 @@ monty_sample_steps <- function(n_steps, burnin = NULL, thinning_factor = NULL,
   }
   ret <- list(total = n_steps,
               burnin = burnin,
-              thinning_factor = thinning_factor)
+              thinning_factor = thinning_factor,
+              save_full_chains = save_full_chains)
   class(ret) <- "monty_sample_steps"
   ret
 }
@@ -485,10 +496,11 @@ combine_state_chain <- function(state) {
 }
 
 
-monty_samples <- function(pars, density, initial, details, observations,
-                          state) {
+monty_samples <- function(pars, pars_full, density, initial, details,
+                          observations, state) {
   rownames(initial) <- rownames(pars)
   samples <- list(pars = pars,
+                  pars_full = pars_full,
                   density = density,
                   initial = initial,
                   details = details,

--- a/R/sample.R
+++ b/R/sample.R
@@ -207,7 +207,7 @@ monty_sample_continue <- function(samples, n_steps, restartable = FALSE,
 
   burnin <- NULL
   thinning_factor <- samples$restart$thinning_factor
-  save_full_chains <- !is.null(samples$pars_full)
+  save_full_chains <- !is.null(samples$full_chains)
   steps <- monty_sample_steps(n_steps, burnin, thinning_factor,
                               save_full_chains)
 
@@ -425,9 +425,8 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
   }
   if (!is.null(prev$full_chains) && !is.null(curr$full_chains)) {
     full_chains <- list(
-      pars_full = 
-        array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2),
-      density_full = 
+      pars = array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2),
+      density = 
         array_bind(prev$full_chains$density, curr$full_chains$density, on = 1)
     )
   } else {

--- a/R/sample.R
+++ b/R/sample.R
@@ -368,17 +368,23 @@ combine_chains <- function(res, sampler, observer, include_state) {
   ## First, process the core history:
   history <- lapply(res, "[[", "history")
   pars <- array_bind(arrays = lapply(history, "[[", "pars"), after = 2)
-  if (!is.null(history[[1]]$pars_full)) {
-    pars_full <- 
-      array_bind(arrays = lapply(history, "[[", "pars_full"), after = 2)
-  } else {
-    pars_full <- NULL
-  } 
   density <- array_bind(arrays = lapply(history, "[[", "density"), after = 1)
   if (is.null(observer)) {
     observations <- NULL
   } else {
     observations <- observer$combine(lapply(history, "[[", "observations"))
+  }
+  
+  full_chains <- lapply(history, "[[", "full_chains")
+  if (!is.null(full_chains[[1]])) {
+    pars_full <- 
+      array_bind(arrays = lapply(full_chains, "[[", "pars"), after = 2)
+    density_full <- 
+      array_bind(arrays = lapply(full_chains, "[[", "density"), after = 1)
+    full_chains <- list(pars = pars_full,
+                        density = density_full)
+  } else {
+    full_chains <- NULL
   }
 
   initial <- array_bind(arrays = lapply(res, "[[", "initial"), after = 1)
@@ -406,7 +412,8 @@ combine_chains <- function(res, sampler, observer, include_state) {
     state <- NULL
   }
 
-  monty_samples(pars, pars_full, density, initial, details, observations, state)
+  monty_samples(pars, density, initial, details, observations, state,
+                full_chains)
 }
 
 
@@ -416,19 +423,24 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
   } else {
     observations <- observer$append(prev$observations, curr$observations)
   }
-  if (!is.null(prev$pars_full) && !is.null(curr$pars_full)) {
-    pars_full <- array_bind(prev$pars_full, curr$pars_full, on = 2)
+  if (!is.null(prev$full_chains) && !is.null(curr$full_chains)) {
+    full_chains <- list(
+      pars_full = 
+        array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2),
+      density_full = 
+        array_bind(prev$full_chains$density, curr$full_chains$density, on = 1)
+    )
   } else {
-    pars_full <- NULL
+    full_chains <- NULL
   }
   
   samples <- list(pars = array_bind(prev$pars, curr$pars, on = 2),
-                  pars_full = pars_full,
                   density = array_bind(prev$density, curr$density, on = 1),
                   initial = prev$initial,
                   details = curr$details,
                   state = curr$state,
-                  observations = observations)
+                  observations = observations,
+                  full_chains = full_chains)
   class(samples) <- "monty_samples"
   samples
 }
@@ -514,16 +526,16 @@ combine_state_chain <- function(state) {
 }
 
 
-monty_samples <- function(pars, pars_full, density, initial, details,
-                          observations, state) {
+monty_samples <- function(pars, density, initial, details, observations,
+                          state, full_chains) {
   rownames(initial) <- rownames(pars)
   samples <- list(pars = pars,
-                  pars_full = pars_full,
                   density = density,
                   initial = initial,
                   details = details,
                   state = state,
-                  observations = observations)
+                  observations = observations,
+                  full_chains = full_chains)
   class(samples) <- "monty_samples"
   samples
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -383,8 +383,7 @@ combine_chains <- function(res, sampler, observer, include_state) {
       array_bind(arrays = lapply(full_chains, "[[", "pars"), after = 2)
     density_full <- 
       array_bind(arrays = lapply(full_chains, "[[", "density"), after = 1)
-    full_chains <- monty_samples(pars_full, density_full, initial,
-                                 NULL, NULL, NULL, NULL)
+    full_chains <- monty_samples(pars_full, density_full, initial)
   } else {
     full_chains <- NULL
   }
@@ -428,8 +427,7 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
       array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2)
     density_full <- 
       array_bind(prev$full_chains$density, curr$full_chains$density, on = 1)
-    full_chains <- monty_samples(pars_full, density_full, prev$initial,
-                                 NULL, NULL, NULL, NULL)
+    full_chains <- monty_samples(pars_full, density_full, prev$initial)
   } else {
     full_chains <- NULL
   }
@@ -524,8 +522,9 @@ combine_state_chain <- function(state) {
 }
 
 
-monty_samples <- function(pars, density, initial, details, observations,
-                          state, full_chains) {
+monty_samples <- function(pars, density, initial,
+                          details = NULL, observations = NULL,
+                          state = NULL, full_chains = NULL) {
   rownames(initial) <- rownames(pars)
   samples <- list(pars = pars,
                   density = density,

--- a/R/sample.R
+++ b/R/sample.R
@@ -97,7 +97,7 @@
 ##' * `observations`: Additional details reported by the model.  This
 ##'   one is also subject to change.
 ##'
-##' * `full-chains`: If `save_full_chains = TRUE`, an list containing `pars`
+##' * `full_chains`: If `save_full_chains = TRUE`, a list including `pars`
 ##'   and `density` without discarding the burnin and thinning.
 ##'   If `save_full_chains = FALSE`, this will be `NULL`.
 ##'
@@ -374,6 +374,8 @@ combine_chains <- function(res, sampler, observer, include_state) {
   } else {
     observations <- observer$combine(lapply(history, "[[", "observations"))
   }
+
+  initial <- array_bind(arrays = lapply(res, "[[", "initial"), after = 1)
   
   full_chains <- lapply(history, "[[", "full_chains")
   if (!is.null(full_chains[[1]])) {
@@ -381,13 +383,11 @@ combine_chains <- function(res, sampler, observer, include_state) {
       array_bind(arrays = lapply(full_chains, "[[", "pars"), after = 2)
     density_full <- 
       array_bind(arrays = lapply(full_chains, "[[", "density"), after = 1)
-    full_chains <- list(pars = pars_full,
-                        density = density_full)
+    full_chains <- monty_samples(pars_full, density_full, initial,
+                                 NULL, NULL, NULL, NULL)
   } else {
     full_chains <- NULL
   }
-
-  initial <- array_bind(arrays = lapply(res, "[[", "initial"), after = 1)
 
   ## Then process the internal state of all the components
   state <- lapply(res, "[[", "state")
@@ -423,25 +423,24 @@ append_chains <- function(prev, curr, sampler, observer = NULL) {
   } else {
     observations <- observer$append(prev$observations, curr$observations)
   }
-  if (!is.null(prev$full_chains) && !is.null(curr$full_chains)) {
-    full_chains <- list(
-      pars = array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2),
-      density = 
-        array_bind(prev$full_chains$density, curr$full_chains$density, on = 1)
-    )
+  if (!is.null(prev$full_chains)) {
+    pars_full <- 
+      array_bind(prev$full_chains$pars, curr$full_chains$pars, on = 2)
+    density_full <- 
+      array_bind(prev$full_chains$density, curr$full_chains$density, on = 1)
+    full_chains <- monty_samples(pars_full, density_full, prev$initial,
+                                 NULL, NULL, NULL, NULL)
   } else {
     full_chains <- NULL
   }
   
-  samples <- list(pars = array_bind(prev$pars, curr$pars, on = 2),
-                  density = array_bind(prev$density, curr$density, on = 1),
-                  initial = prev$initial,
-                  details = curr$details,
-                  state = curr$state,
-                  observations = observations,
-                  full_chains = full_chains)
-  class(samples) <- "monty_samples"
-  samples
+  monty_samples(pars = array_bind(prev$pars, curr$pars, on = 2),
+                density = array_bind(prev$density, curr$density, on = 1),
+                initial = prev$initial,
+                details = curr$details,
+                observations = observations,
+                state = curr$state,
+                full_chains = full_chains)
 }
 
 

--- a/R/samples-tools.R
+++ b/R/samples-tools.R
@@ -36,12 +36,19 @@
 ##'
 ##' @param burnin Number of steps to discard as burnin from the start
 ##'   of the chain.
+##'   
+##' @param save_full_chains Logical, indicating whether or not the full chains
+##'   of the parameters (without discarding the burnin and thinning) should
+##'   additionally be saved. This is useful if you are thinning to reduce the
+##'   size of observations but still want to retain the full chains of the
+##'   parameters for evaluation purposes.
 ##'
 ##' @return A `monty_samples` object (as for [monty_sample()]),
 ##'   typically with fewer samples.
 ##'
 ##' @export
-monty_samples_thin <- function(samples, thinning_factor = NULL, burnin = NULL) {
+monty_samples_thin <- function(samples, thinning_factor = NULL, burnin = NULL,
+                               save_full_chains = FALSE) {
   assert_is(samples, "monty_samples")
 
   n_samples <- ncol(samples$pars)
@@ -71,11 +78,21 @@ monty_samples_thin <- function(samples, thinning_factor = NULL, burnin = NULL) {
     return(samples)
   }
 
-  monty_samples_subset(samples, keep)
+  monty_samples_subset(samples, keep, save_full_chains)
 }
 
 
-monty_samples_subset <- function(samples, i) {
+monty_samples_subset <- function(samples, i, save_full_chains = FALSE) {
+  
+  if (save_full_chains) {
+    if (is.null(samples$full_chains)) {
+      samples$full_chains <- list(pars = samples$pars,
+                                  density = samples$density)
+    }
+  } else {
+    samples$full_chains <- NULL
+  }
+  
   len <- dim(samples$density)
 
   samples$pars <- samples$pars[, i, , drop = FALSE]

--- a/R/samples-tools.R
+++ b/R/samples-tools.R
@@ -90,7 +90,7 @@ monty_samples_subset <- function(samples, i, save_full_chains = FALSE) {
                                   density = samples$density)
     }
   } else {
-    samples$full_chains <- NULL
+    samples["full_chains"] <- list(NULL)
   }
   
   len <- dim(samples$density)

--- a/R/samples-tools.R
+++ b/R/samples-tools.R
@@ -87,8 +87,7 @@ monty_samples_subset <- function(samples, i, save_full_chains = FALSE) {
   if (save_full_chains) {
     if (is.null(samples$full_chains)) {
       samples$full_chains <- 
-        monty_samples(samples$pars, samples$density, samples$initial,
-                      NULL, NULL, NULL, NULL)
+        monty_samples(samples$pars, samples$density, samples$initial)
     }
   } else {
     samples["full_chains"] <- list(NULL)

--- a/R/samples-tools.R
+++ b/R/samples-tools.R
@@ -86,8 +86,9 @@ monty_samples_subset <- function(samples, i, save_full_chains = FALSE) {
   
   if (save_full_chains) {
     if (is.null(samples$full_chains)) {
-      samples$full_chains <- list(pars = samples$pars,
-                                  density = samples$density)
+      samples$full_chains <- 
+        monty_samples(samples$pars, samples$density, samples$initial,
+                      NULL, NULL, NULL, NULL)
     }
   } else {
     samples["full_chains"] <- list(NULL)

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -93,9 +93,6 @@ parameter, sample and chain, so that \code{pars[i, j, k]} is the
 \code{i}th parameter from the \code{j}th sample from the \code{k}th chain.  The
 rows will be named with the names of the parameters, from your
 model.
-\item \code{pars_full}: If \code{save_full_chains = TRUE}, an array representing \code{pars}
-without discarding the burnin and thinning. If \code{save_full_chains = FALSE},
-this will be \code{NULL}.
 \item \code{density}: A matrix of model log densities, with \code{n_steps} rows
 and \code{n_chains} columns.
 \item \code{initial}: A record of the initial conditions, a matrix with as
@@ -107,6 +104,9 @@ be a list of length \code{n_chains} (or \code{NULL}) and the details
 depend on the sampler.  This one is subject to change.
 \item \code{observations}: Additional details reported by the model.  This
 one is also subject to change.
+\item \code{full-chains}: If \code{save_full_chains = TRUE}, an list containing \code{pars}
+and \code{density} without discarding the burnin and thinning.
+If \code{save_full_chains = FALSE}, this will be \code{NULL}.
 }
 }
 \description{

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -13,7 +13,8 @@ monty_sample(
   runner = NULL,
   restartable = FALSE,
   burnin = NULL,
-  thinning_factor = NULL
+  thinning_factor = NULL,
+  save_full_chains = FALSE
 )
 }
 \arguments{
@@ -72,6 +73,12 @@ is an even multiple of \code{thinning_factor}; so if
 \code{thinning_factor} is 10, then \code{n_steps} must be a multiple of
 10.  This ensures that the last step is in the sample.  The
 thinning factor cannot be changed when continuing a chain.}
+
+\item{save_full_chains}{Logical, indicating whether or not the full chains
+of the parameters (without discarding the burnin and thinning) should
+additionally be saved. This is useful if you are thinning to reduce the
+size of observations but still want to retain the full chains of the
+parameters for evaluation purposes.}
 }
 \value{
 A list of parameters and densities.  We provide conversion
@@ -86,6 +93,9 @@ parameter, sample and chain, so that \code{pars[i, j, k]} is the
 \code{i}th parameter from the \code{j}th sample from the \code{k}th chain.  The
 rows will be named with the names of the parameters, from your
 model.
+\item \code{pars_full}: If \code{save_full_chains = TRUE}, an array representing \code{pars}
+without discarding the burnin and thinning. If \code{save_full_chains = FALSE},
+this will be \code{NULL}.
 \item \code{density}: A matrix of model log densities, with \code{n_steps} rows
 and \code{n_chains} columns.
 \item \code{initial}: A record of the initial conditions, a matrix with as
@@ -118,7 +128,7 @@ plot(pars, pch = 19, cex = 0.75, col = "#0000ff55")
 
 # If you have the posterior package you might prefer converting to
 # its format for performing diagnoses:
-\dontshow{if (requireNamespace("posterior")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("posterior")) withAutoprint(\{ # examplesIf}
 res <- posterior::as_draws_df(samples)
 posterior::summarise_draws(res)
 

--- a/man/monty_sample.Rd
+++ b/man/monty_sample.Rd
@@ -83,8 +83,8 @@ parameters for evaluation purposes.}
 \value{
 A list of parameters and densities.  We provide conversion
 to formats used by other packages, notably
-\link[posterior:draws_array]{posterior::as_draws_array}, \link[posterior:draws_df]{posterior::as_draws_df} and
-\link[coda:mcmc.list]{coda::as.mcmc.list}; please let us know if you need conversion
+\link[posterior:as_draws_array]{posterior::as_draws_array}, \link[posterior:as_draws_df]{posterior::as_draws_df} and
+\link[coda:as.mcmc.list]{coda::as.mcmc.list}; please let us know if you need conversion
 to something else.  If you want to work directly with the
 output, the elements in the list include:
 \itemize{
@@ -104,7 +104,7 @@ be a list of length \code{n_chains} (or \code{NULL}) and the details
 depend on the sampler.  This one is subject to change.
 \item \code{observations}: Additional details reported by the model.  This
 one is also subject to change.
-\item \code{full-chains}: If \code{save_full_chains = TRUE}, an list containing \code{pars}
+\item \code{full_chains}: If \code{save_full_chains = TRUE}, a list including \code{pars}
 and \code{density} without discarding the burnin and thinning.
 If \code{save_full_chains = FALSE}, this will be \code{NULL}.
 }

--- a/man/monty_sample_manual_prepare.Rd
+++ b/man/monty_sample_manual_prepare.Rd
@@ -12,7 +12,8 @@ monty_sample_manual_prepare(
   initial = NULL,
   n_chains = 1L,
   burnin = NULL,
-  thinning_factor = NULL
+  thinning_factor = NULL,
+  save_full_chains = FALSE
 )
 }
 \arguments{
@@ -73,6 +74,12 @@ is an even multiple of \code{thinning_factor}; so if
 \code{thinning_factor} is 10, then \code{n_steps} must be a multiple of
 10.  This ensures that the last step is in the sample.  The
 thinning factor cannot be changed when continuing a chain.}
+
+\item{save_full_chains}{Logical, indicating whether or not the full chains
+of the parameters (without discarding the burnin and thinning) should
+additionally be saved. This is useful if you are thinning to reduce the
+size of observations but still want to retain the full chains of the
+parameters for evaluation purposes.}
 }
 \value{
 Invisibly, the path used to store files (the same as the

--- a/man/monty_sampler_adaptive.Rd
+++ b/man/monty_sampler_adaptive.Rd
@@ -150,7 +150,7 @@ lines(drop(res_rw$density), type = "l", col = 2)
 # Estimated vcv from the sampler at the end of the simulation
 res_adapt$details$vcv[, , 1]
 
-\dontshow{if (requireNamespace("coda")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("coda")) withAutoprint(\{ # examplesIf}
 coda::effectiveSize(coda::as.mcmc.list(res_rw))
 coda::effectiveSize(coda::as.mcmc.list(res_adapt))
 \dontshow{\}) # examplesIf}

--- a/man/monty_samples_thin.Rd
+++ b/man/monty_samples_thin.Rd
@@ -4,7 +4,12 @@
 \alias{monty_samples_thin}
 \title{Thin samples}
 \usage{
-monty_samples_thin(samples, thinning_factor = NULL, burnin = NULL)
+monty_samples_thin(
+  samples,
+  thinning_factor = NULL,
+  burnin = NULL,
+  save_full_chains = FALSE
+)
 }
 \arguments{
 \item{samples}{A \code{monty_samples} object, from running \code{\link[=monty_sample]{monty_sample()}}}
@@ -17,6 +22,12 @@ chain, and exclude points counting backwards.}
 
 \item{burnin}{Number of steps to discard as burnin from the start
 of the chain.}
+
+\item{save_full_chains}{Logical, indicating whether or not the full chains
+of the parameters (without discarding the burnin and thinning) should
+additionally be saved. This is useful if you are thinning to reduce the
+size of observations but still want to retain the full chains of the
+parameters for evaluation purposes.}
 }
 \value{
 A \code{monty_samples} object (as for \code{\link[=monty_sample]{monty_sample()}}),

--- a/tests/testthat/test-runner-simultaneous.R
+++ b/tests/testthat/test-runner-simultaneous.R
@@ -94,20 +94,22 @@ test_that("can use simultaneous runner with burnin", {
   
   set.seed(1)
   res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
-  expect_equal(res1$pars_full, NULL)
+  expect_equal(res1$full_chains, NULL)
   
   set.seed(1)
   res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        burnin = 10)
   expect_equal(res2$pars, res1$pars[, 11:30, , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, res1$density[11:30, , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        burnin = 10, save_full_chains = TRUE)
   expect_equal(res3$pars, res1$pars[, 11:30, , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
-  
+  expect_equal(res3$density, res1$density[11:30, , drop = FALSE])
+  expect_equal(res3$full_chains$pars, res1$pars)
+  expect_equal(res3$full_chains$density, res1$density)
 })
 
 
@@ -120,49 +122,27 @@ test_that("can use simultaneous runner with thinning", {
   
   set.seed(1)
   res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
-  expect_equal(res1$pars_full, NULL)
+  expect_equal(res1$full_chains, NULL)
   
   set.seed(1)
   res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        thinning_factor = 2)
   expect_equal(res2$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, res1$density[seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        thinning_factor = 2, save_full_chains = TRUE)
   expect_equal(res3$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
+  expect_equal(res3$density, res1$density[seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res3$full_chains$pars, res1$pars)
+  expect_equal(res3$full_chains$density, res1$density)
   
 })
 
 
-test_that("can use simultaneous runner with thinning", {
-  m <- ex_simple_gamma1()
-  vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
-  sampler <- monty_sampler_random_walk(vcv = vcv)
-  runner <- monty_runner_simultaneous()
-  n_steps <- 30
-  
-  set.seed(1)
-  res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
-  expect_equal(res1$pars_full, NULL)
-  
-  set.seed(1)
-  res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
-                       thinning_factor = 2)
-  expect_equal(res2$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
-  
-  set.seed(1)
-  res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
-                       thinning_factor = 2, save_full_chains = TRUE)
-  expect_equal(res3$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
-})
-
-
-test_that("can use simultaneous runner with thinning", {
+test_that("can use simultaneous runner with burnin and thinning", {
   m <- ex_simple_gamma1()
   vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
   sampler <- monty_sampler_random_walk(vcv = vcv)
@@ -177,12 +157,15 @@ test_that("can use simultaneous runner with thinning", {
   res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        burnin = 15, thinning_factor = 2)
   expect_equal(res2$pars, res1$pars[, seq(16, 30, by = 2), , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, res1$density[seq(16, 30, by = 2), , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
                        burnin = 15, thinning_factor = 2,
                        save_full_chains = TRUE)
   expect_equal(res3$pars, res1$pars[, seq(16, 30, by = 2), , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
+  expect_equal(res3$density, res1$density[seq(16, 30, by = 2), , drop = FALSE])
+  expect_equal(res3$full_chains$pars, res1$pars)
+  expect_equal(res3$full_chains$density, res1$density)
 })

--- a/tests/testthat/test-runner-simultaneous.R
+++ b/tests/testthat/test-runner-simultaneous.R
@@ -83,3 +83,106 @@ test_that("can simultaneously sample a single chain", {
   expect_equal(res1, res2)
   expect_equal(res3$density[, 1, drop = FALSE], res1$density)
 })
+
+
+test_that("can use simultaneous runner with burnin", {
+  m <- ex_simple_gamma1()
+  vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
+  sampler <- monty_sampler_random_walk(vcv = vcv)
+  runner <- monty_runner_simultaneous()
+  n_steps <- 30
+  
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
+  expect_equal(res1$pars_full, NULL)
+  
+  set.seed(1)
+  res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       burnin = 10)
+  expect_equal(res2$pars, res1$pars[, 11:30, , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       burnin = 10, save_full_chains = TRUE)
+  expect_equal(res3$pars, res1$pars[, 11:30, , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
+  
+})
+
+
+test_that("can use simultaneous runner with thinning", {
+  m <- ex_simple_gamma1()
+  vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
+  sampler <- monty_sampler_random_walk(vcv = vcv)
+  runner <- monty_runner_simultaneous()
+  n_steps <- 30
+  
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
+  expect_equal(res1$pars_full, NULL)
+  
+  set.seed(1)
+  res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       thinning_factor = 2)
+  expect_equal(res2$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       thinning_factor = 2, save_full_chains = TRUE)
+  expect_equal(res3$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
+  
+})
+
+
+test_that("can use simultaneous runner with thinning", {
+  m <- ex_simple_gamma1()
+  vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
+  sampler <- monty_sampler_random_walk(vcv = vcv)
+  runner <- monty_runner_simultaneous()
+  n_steps <- 30
+  
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
+  expect_equal(res1$pars_full, NULL)
+  
+  set.seed(1)
+  res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       thinning_factor = 2)
+  expect_equal(res2$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       thinning_factor = 2, save_full_chains = TRUE)
+  expect_equal(res3$pars, res1$pars[, seq(2, 30, by = 2), , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
+})
+
+
+test_that("can use simultaneous runner with thinning", {
+  m <- ex_simple_gamma1()
+  vcv <- array(1 * 10^c(-4, -3, -2, -1, 0), c(1, 1, 5))
+  sampler <- monty_sampler_random_walk(vcv = vcv)
+  runner <- monty_runner_simultaneous()
+  n_steps <- 30
+  
+  set.seed(1)
+  res1 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner)
+  expect_equal(res1$pars_full, NULL)
+  
+  set.seed(1)
+  res2 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       burnin = 15, thinning_factor = 2)
+  expect_equal(res2$pars, res1$pars[, seq(16, 30, by = 2), , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(m, sampler, n_steps, n_chains = 5, runner = runner,
+                       burnin = 15, thinning_factor = 2,
+                       save_full_chains = TRUE)
+  expect_equal(res3$pars, res1$pars[, seq(16, 30, by = 2), , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
+})

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -19,7 +19,8 @@ test_that("sampler return value contains history", {
   res <- monty_sample(model, sampler, 100, 1)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "state", "observations"))
+    c("pars", "pars_full", "density", "initial",
+      "details", "state", "observations"))
   expect_equal(dim(res$pars), c(1, 100, 1))
   expect_equal(dimnames(res$pars), list("gamma", NULL, NULL))
   expect_equal(dim(res$density), c(100, 1))

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -501,11 +501,12 @@ test_that("can continue thinned chain, continues thinning", {
 
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 1, n_chains = 3,
-                       thinning_factor = 4)
+                       thinning_factor = 4, save_full_chains = TRUE)
 
   set.seed(1)
   res2a <- monty_sample(model, sampler, 60, 1, n_chains = 3,
-                        thinning_factor = 4, restartable = TRUE)
+                        thinning_factor = 4, restartable = TRUE,
+                        save_full_chains = TRUE)
   res2b <- monty_sample_continue(res2a, 40)
 
   expect_equal(res2b, res1)

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -19,8 +19,8 @@ test_that("sampler return value contains history", {
   res <- monty_sample(model, sampler, 100, 1)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial",
-      "details", "state", "observations"))
+    c("pars", "density", "initial", "details",
+      "state", "observations", "full_chains"))
   expect_equal(dim(res$pars), c(1, 100, 1))
   expect_equal(dimnames(res$pars), list("gamma", NULL, NULL))
   expect_equal(dim(res$density), c(100, 1))
@@ -392,18 +392,21 @@ test_that("can sample with burnin", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
-  expect_equal(res1$pars_full, NULL)
+  expect_equal(res1$full_chains, NULL)
   
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3, burnin = 30)
   expect_equal(res2$pars, res1$pars[, 31:100, , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, res1$density[31:100, , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(model, sampler, 100, 3, burnin = 30,
                        save_full_chains = TRUE)
-  expect_equal(res2$pars, res1$pars[, 31:100, , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
+  expect_equal(res3$pars, res1$pars[, 31:100, , drop = FALSE])
+  expect_equal(res3$density, res1$density[31:100, , drop = FALSE])
+  expect_equal(res3$full_chains$pars, res1$pars)
+  expect_equal(res3$full_chains$density, res1$density)
 })
 
 
@@ -412,18 +415,21 @@ test_that("can sample with thinning", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
-  expect_equal(res1$pars_full, NULL)
+  expect_equal(res1$full_chains, NULL)
   
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3, thinning_factor = 4)
   expect_equal(res2$pars, res1$pars[, seq(4, 100, by = 4), , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, res1$density[seq(4, 100, by = 4), , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(model, sampler, 100, 3, thinning_factor = 4,
                        save_full_chains = TRUE)
   expect_equal(res3$pars, res1$pars[, seq(4, 100, by = 4), , drop = FALSE])
-  expect_equal(res3$pars_full, res1$pars)
+  expect_equal(res3$density, res1$density[seq(4, 100, by = 4), , drop = FALSE])
+  expect_equal(res3$full_chains$pars, res1$pars)
+  expect_equal(res3$full_chains$density, res1$density)
 })
 
 
@@ -432,34 +438,44 @@ test_that("can sample with burnin and thinning", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
-  expect_equal(res1$pars_full, NULL)
+  expect_equal(res1$full_chains, NULL)
   
   ## Pick deliberately hard values here:
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3,
                        burnin = 25, thinning_factor = 10)
   expect_equal(res2$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
-  expect_equal(res2$pars_full, NULL)
+  expect_equal(res2$density, 
+               res1$density[seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res2$full_chains, NULL)
   
   set.seed(1)
   res3 <- monty_sample(model, sampler, 100, 3,
                        burnin = 20, thinning_factor = 10)
   expect_equal(res3$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
-  expect_equal(res3$pars_full, NULL)
+  expect_equal(res3$density,
+               res1$density[seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res3$full_chains, NULL)
   
   set.seed(1)
   res4 <- monty_sample(model, sampler, 100, 3,
                        burnin = 25, thinning_factor = 10,
                        save_full_chains = TRUE)
   expect_equal(res4$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
-  expect_equal(res4$pars_full, res1$pars)
+  expect_equal(res4$density, 
+               res1$density[seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res4$full_chains$pars, res1$pars)
+  expect_equal(res4$full_chains$density, res1$density)
   
   set.seed(1)
   res5 <- monty_sample(model, sampler, 100, 3,
                        burnin = 20, thinning_factor = 10,
                        save_full_chains = TRUE)
   expect_equal(res5$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
-  expect_equal(res5$pars_full, res1$pars)
+  expect_equal(res5$density,
+               res1$density[seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res5$full_chains$pars, res1$pars)
+  expect_equal(res5$full_chains$density, res1$density)
 })
 
 

--- a/tests/testthat/test-sample.R
+++ b/tests/testthat/test-sample.R
@@ -392,9 +392,18 @@ test_that("can sample with burnin", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
+  expect_equal(res1$pars_full, NULL)
+  
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3, burnin = 30)
   expect_equal(res2$pars, res1$pars[, 31:100, , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(model, sampler, 100, 3, burnin = 30,
+                       save_full_chains = TRUE)
+  expect_equal(res2$pars, res1$pars[, 31:100, , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
 })
 
 
@@ -403,9 +412,18 @@ test_that("can sample with thinning", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
+  expect_equal(res1$pars_full, NULL)
+  
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3, thinning_factor = 4)
   expect_equal(res2$pars, res1$pars[, seq(4, 100, by = 4), , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
+  set.seed(1)
+  res3 <- monty_sample(model, sampler, 100, 3, thinning_factor = 4,
+                       save_full_chains = TRUE)
+  expect_equal(res3$pars, res1$pars[, seq(4, 100, by = 4), , drop = FALSE])
+  expect_equal(res3$pars_full, res1$pars)
 })
 
 
@@ -414,15 +432,34 @@ test_that("can sample with burnin and thinning", {
   sampler <- monty_sampler_random_walk(vcv = diag(1) * 0.01)
   set.seed(1)
   res1 <- monty_sample(model, sampler, 100, 3)
+  expect_equal(res1$pars_full, NULL)
+  
   ## Pick deliberately hard values here:
   set.seed(1)
   res2 <- monty_sample(model, sampler, 100, 3,
                        burnin = 25, thinning_factor = 10)
   expect_equal(res2$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res2$pars_full, NULL)
+  
   set.seed(1)
   res3 <- monty_sample(model, sampler, 100, 3,
                        burnin = 20, thinning_factor = 10)
   expect_equal(res3$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res3$pars_full, NULL)
+  
+  set.seed(1)
+  res4 <- monty_sample(model, sampler, 100, 3,
+                       burnin = 25, thinning_factor = 10,
+                       save_full_chains = TRUE)
+  expect_equal(res4$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res4$pars_full, res1$pars)
+  
+  set.seed(1)
+  res5 <- monty_sample(model, sampler, 100, 3,
+                       burnin = 20, thinning_factor = 10,
+                       save_full_chains = TRUE)
+  expect_equal(res5$pars, res1$pars[, seq(30, 100, by = 10), , drop = FALSE])
+  expect_equal(res5$pars_full, res1$pars)
 })
 
 

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -8,8 +8,8 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0", {
 
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
 
   ## forget_rate = 0 so full chain should be included in VCV
   expect_equal(res$details$weight[[1]], 1000)
@@ -28,8 +28,8 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0.1", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
 
   ## forget_rate = 0.1 so VCV should exclude first 100 parameter sets
   expect_equal(res$details$weight[[1]], 900)
@@ -47,8 +47,8 @@ test_that("Empirical VCV correct using both forget_rate and forget_end", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
 
   ## forget_rate = 0.5 and forget_end = 200 so VCV should exclude first
   ## 100 parameter sets
@@ -68,8 +68,8 @@ test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
 
   ## forget_rate = 0.25, forget_end = 500 and adapt_end = 300 so VCV should
   ## only include parameter sets 26 to 300

--- a/tests/testthat/test-sampler-adaptive.R
+++ b/tests/testthat/test-sampler-adaptive.R
@@ -8,7 +8,8 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0", {
 
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "observations", "state"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
 
   ## forget_rate = 0 so full chain should be included in VCV
   expect_equal(res$details$weight[[1]], 1000)
@@ -27,7 +28,8 @@ test_that("Empirical VCV calculated correctly with forget_rate = 0.1", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "observations", "state"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
 
   ## forget_rate = 0.1 so VCV should exclude first 100 parameter sets
   expect_equal(res$details$weight[[1]], 900)
@@ -45,7 +47,8 @@ test_that("Empirical VCV correct using both forget_rate and forget_end", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "observations", "state"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
 
   ## forget_rate = 0.5 and forget_end = 200 so VCV should exclude first
   ## 100 parameter sets
@@ -65,7 +68,8 @@ test_that("Empirical VCV correct using forget_rate, forget_end and adapt_end", {
   res <- monty_sample(m, sampler, 1000)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "observations", "state"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
 
   ## forget_rate = 0.25, forget_end = 500 and adapt_end = 300 so VCV should
   ## only include parameter sets 26 to 300

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -5,8 +5,8 @@ test_that("can draw samples from a trivial model", {
 
   expect_equal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "state", "observations"))
+    c("pars", "density", "initial", "details",
+      "state", "observations", "full_chains"))
   expect_equal(dim(res$pars), c(1, 100, 1))
 })
 
@@ -35,8 +35,8 @@ test_that("can draw samples from a random model", {
   res <- monty_sample(m, sampler, 20)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
 })
 
 
@@ -50,8 +50,8 @@ test_that("can observe a model", {
   res <- monty_sample(m, sampler, 20, n_chains = 3)
   expect_setequal(
     names(res),
-    c("pars", "pars_full", "density", "initial", 
-      "details", "observations", "state"))
+    c("pars", "density", "initial", "details",
+      "observations", "state", "full_chains"))
   expect_equal(names(res$observations),
                "trajectories")
   expect_equal(dim(res$observations$trajectories),

--- a/tests/testthat/test-sampler-random-walk.R
+++ b/tests/testthat/test-sampler-random-walk.R
@@ -5,7 +5,8 @@ test_that("can draw samples from a trivial model", {
 
   expect_equal(
     names(res),
-    c("pars", "density", "initial", "details", "state", "observations"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "state", "observations"))
   expect_equal(dim(res$pars), c(1, 100, 1))
 })
 
@@ -34,7 +35,8 @@ test_that("can draw samples from a random model", {
   res <- monty_sample(m, sampler, 20)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "state", "observations"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
 })
 
 
@@ -48,7 +50,8 @@ test_that("can observe a model", {
   res <- monty_sample(m, sampler, 20, n_chains = 3)
   expect_setequal(
     names(res),
-    c("pars", "density", "initial", "details", "state", "observations"))
+    c("pars", "pars_full", "density", "initial", 
+      "details", "observations", "state"))
   expect_equal(names(res$observations),
                "trajectories")
   expect_equal(dim(res$observations$trajectories),

--- a/tests/testthat/test-samples-tools.R
+++ b/tests/testthat/test-samples-tools.R
@@ -9,6 +9,7 @@ test_that("can thin chain", {
   res1 <- monty_samples_thin(res, burnin = 100)
   expect_equal(res1$pars, res$pars[, -(1:100), , drop = FALSE])
   expect_equal(res1$density, res$density[-(1:100), , drop = FALSE])
+  expect_equal(res1$full_chains, NULL)
   expect_equal(res1, monty_samples_subset(res, 101:500))
 
   res2 <- monty_samples_thin(res, thinning_factor = 10)
@@ -18,6 +19,27 @@ test_that("can thin chain", {
   res3 <- monty_samples_thin(res, burnin = 123, thinning_factor = 17)
   i <- seq(126, 500, by = 17)
   expect_equal(res3, monty_samples_subset(res, i))
+  
+  res1a <- monty_samples_thin(res, burnin = 100, save_full_chains = TRUE)
+  expect_equal(res1a$pars, res$pars[, -(1:100), , drop = FALSE])
+  expect_equal(res1a$density, res$density[-(1:100), , drop = FALSE])
+  expect_equal(res1a, monty_samples_subset(res, 101:500, TRUE))
+  expect_equal(res1a$full_chains$pars, res$pars)
+  expect_equal(res1a$full_chains$density, res$density)
+  
+  res2a <- monty_samples_thin(res, thinning_factor = 10,
+                              save_full_chains = TRUE)
+  i <- seq(10, 500, by = 10)
+  expect_equal(res2a, monty_samples_subset(res, i, TRUE))
+  expect_equal(res2a$full_chains$pars, res$pars)
+  expect_equal(res2a$full_chains$density, res$density)
+  
+  res3a <- monty_samples_thin(res, burnin = 123, thinning_factor = 17,
+                              save_full_chains = TRUE)
+  i <- seq(126, 500, by = 17)
+  expect_equal(res3a, monty_samples_subset(res, i, TRUE))
+  expect_equal(res3a$full_chains$pars, res$pars)
+  expect_equal(res3a$full_chains$density, res$density)
 })
 
 


### PR DESCRIPTION
In mcstate when thinning (and/or discarding burnin), the full chains of the parameters and densities were retained (useful for running diagnostics or making traceplots).

With `monty` there are two ways to thin:
1. by setting `burnin` and/or `thinning_factor` in `monty_sample` (so you thin as you go along)
2. by thinning after running using `monty_samples_thin`

Neither method allowed individuals to retain the full chains of the parameters. With the mpox model I would use method 2 and separately save the full chains of parameters before thinning (the main purpose of thinning in this case was to cut down on file size, most of which is due to the trajectories which are typically make for a much larger object than the parameters array).

The issue with that approach is if you run chains long enough you can run out of memory - thinning as you go along solves this problem but at the moment it is impossible to recover the full chains.

Adding this option to both thinning methods makes this easier in general for users.



Some code to try

```
m <- monty_dsl({
  a ~ Exponential(1)
  b ~ Normal(0, 1)
})

sampler <- monty_sampler_hmc()


## running without thinning
set.seed(1)
res1 <- monty_sample(m, sampler, 1000, n_chains = 4)


## running with thinning but not saving full chains
set.seed(1)
res2 <- monty_sample(m, sampler, 1000, n_chains = 4,
                     burnin = 500, thinning_factor = 2)
identical(res2$full_chains, NULL)


## running with thinning, saving full chains
set.seed(1)
res3 <- monty_sample(m, sampler, 1000, n_chains = 4,
                     burnin = 500, thinning_factor = 2, save_full_chains = TRUE)
identical(res3$full_chains$pars, res1$pars)
identical(res3$full_chains$density, res1$density)


## thinning after running, results will be same as thinning while running
res4 <- monty_samples_thin(res1, burnin = 500, thinning_factor = 2)
identical(res2, res4)

res5 <- monty_samples_thin(res1, burnin = 500, thinning_factor = 2,
                           save_full_chains = TRUE)
identical(res3, res5)

## full_chains is a monty_samples object so can be converted with
## posterior::as_draws_df (for e.g. diagnostics)
res1_df <- posterior::as_draws_df(res1)
res3_df <- posterior::as_draws_df(res3$full_chains)
identical(res1_df, res3_df)
```