### PR TITLE
Rename grouped parameters and fix index function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: monty
 Title: Monte Carlo Models
-Version: 0.4.11
+Version: 0.4.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Wes", "Hinsley", role = "aut"),

--- a/R/packer-grouped.R
+++ b/R/packer-grouped.R
@@ -224,8 +224,19 @@ monty_packer_grouped <- function(groups, scalar = NULL, array = NULL,
     x
   }
 
-  idx <- unpack(seq_len(len))
-
+  #idx <- unpack(seq_len(len))
+  
+  ## This is a simplified version of unpack above to create index
+  base <- c(set_names(vector("list", length(nms)), nms))
+  base[shared] <- d_shared$packer$unpack(d_shared$index_packed)
+  idx <- rep(list(base), n_groups)
+  x_varied <- matrix(d_varied$index_packed, n_varied, n_groups)
+  for (i in seq_len(n_groups)) {
+    idx[[i]][varied] <- d_varied$packer$unpack(x_varied[, i])
+  }
+  names(idx) <- groups
+  
+  
   ## This would be really quite hard, and I'm not sure how effective?
   ## But we might want it later to support multistage simulation in
   ## dust2.

--- a/R/packer-grouped.R
+++ b/R/packer-grouped.R
@@ -224,8 +224,6 @@ monty_packer_grouped <- function(groups, scalar = NULL, array = NULL,
     x
   }
 
-  #idx <- unpack(seq_len(len))
-  
   ## This is a simplified version of unpack above to create index
   base <- c(set_names(vector("list", length(nms)), nms))
   base[shared] <- d_shared$packer$unpack(d_shared$index_packed)

--- a/R/packer-grouped.R
+++ b/R/packer-grouped.R
@@ -177,7 +177,7 @@ monty_packer_grouped <- function(groups, scalar = NULL, array = NULL,
   ## group:parameter
   names_expanded <- c(d_shared$packer$names(),
                       outer(d_varied$packer$names(), groups,
-                            function(g, p) sprintf("%s<%s>", g, p)))
+                            function(g, p) sprintf("%s | %s", g, p)))
 
   unpack <- function(x) {
     if (!is.null(dim(x))) {

--- a/R/packer-grouped.R
+++ b/R/packer-grouped.R
@@ -224,7 +224,8 @@ monty_packer_grouped <- function(groups, scalar = NULL, array = NULL,
     x
   }
 
-  ## This is a simplified version of unpack above to create index
+  ## This is a simplified version of unpack above to create index,
+  ## here we can ignore fixed data and the process function
   base <- c(set_names(vector("list", length(nms)), nms))
   base[shared] <- d_shared$packer$unpack(d_shared$index_packed)
   idx <- rep(list(base), n_groups)

--- a/R/packer.R
+++ b/R/packer.R
@@ -301,6 +301,10 @@ monty_packer <- function(scalar = NULL, array = NULL, fixed = NULL,
       nms <- c(nms, tmp$names)
       shape[[nm]] <- tmp$shape
       idx[[nm]] <- seq_len(tmp$n) + len
+      if (length(tmp$shape) > 1) {
+        idx[[nm]] <- array(idx[[nm]], tmp$shape)
+      }
+      
       len <- len + tmp$n
     }
   }

--- a/tests/testthat/test-domain.R
+++ b/tests/testthat/test-domain.R
@@ -60,8 +60,8 @@ test_that("Expand domain for grouped packer", {
   packer <- monty_packer_grouped(c("x", "y"), c("a", "b"))
   expect_equal(
     monty_domain_expand(rbind(a = 0:1), packer),
-    rbind("a<x>" = 0:1,
-          "a<y>" = 0:1))
+    rbind("a | x" = 0:1,
+          "a | y" = 0:1))
 })
 
 
@@ -69,8 +69,8 @@ test_that("Expand domain for grouped packer with arrays", {
   packer <- monty_packer_grouped(c("x", "y"), c("a", "b"), list(c = 3, d = 2))
   expected <- cbind(c(0, 0, 0, 0, 2, 0), c(1, 1, 1, 1, 3, 1))
   rownames(expected) <-
-    c("c[1]<x>", "c[2]<x>", "c[3]<x>", "c[1]<y>", "c[2]<y>", "c[3]<y>")
+    c("c[1] | x", "c[2] | x", "c[3] | x", "c[1] | y", "c[2] | y", "c[3] | y")
   expect_equal(
-    monty_domain_expand(rbind(c = 0:1, "c[2]<y>" = 2:3), packer),
+    monty_domain_expand(rbind(c = 0:1, "c[2] | y" = 2:3), packer),
     expected)
 })

--- a/tests/testthat/test-packer-grouped.R
+++ b/tests/testthat/test-packer-grouped.R
@@ -33,6 +33,7 @@ test_that("can use a grouped packer with no shared parameters", {
                list(x = list(a = 1, b = 2, c = 3, d = 4),
                     y = list(a = 5, b = 6, c = 7, d = 8)))
   expect_equal(p$pack(p$unpack(1:8)), 1:8)
+  expect_equal(p$index(), p$unpack(1:8))
 })
 
 
@@ -48,6 +49,7 @@ test_that("can use a grouped packer with no varied parameters", {
                list(x = list(a = 1, b = 2, c = 3, d = 4),
                     y = list(a = 1, b = 2, c = 3, d = 4)))
   expect_equal(p$pack(p$unpack(1:4)), 1:4)
+  expect_equal(p$index(), p$unpack(1:4))
 })
 
 
@@ -64,6 +66,7 @@ test_that("can use a grouped packer with arrays", {
          y = list(a = 10, b = 11, c = 12:14, d = matrix(1:4, 2, 2)),
          z = list(a = 15, b = 16, c = 17:19, d = matrix(1:4, 2, 2))))
   expect_equal(p$pack(p$unpack(1:19)), 1:19)
+  expect_equal(p$index(), p$unpack(1:19))
 })
 
 
@@ -78,6 +81,9 @@ test_that("can use a grouped packer with fixed input", {
     list(x = list(a = 2, b = 3, c = 4, d = 1, m = 1:4),
          y = list(a = 5, b = 6, c = 7, d = 1, m = 1:4)))
   expect_equal(p$pack(p$unpack(1:7)), 1:7)
+  ## due to using fixed input, this will differ from p$unpack(1:7)
+  expect_equal(p$index(), list(x = list(a = 2, b = 3, c = 4, d = 1),
+                               y = list(a = 5, b = 6, c = 7, d = 1)))
 })
 
 

--- a/tests/testthat/test-packer-grouped.R
+++ b/tests/testthat/test-packer-grouped.R
@@ -8,7 +8,7 @@ test_that("can use a grouped packer", {
     c("x", "y", "z"))
   expect_equal(
     p$names(),
-    c("b", "c", "a<x>", "d<x>", "a<y>", "d<y>", "a<z>", "d<z>"))
+    c("b", "c", "a | x", "d | x", "a | y", "d | y", "a | z", "d | z"))
   expect_equal(
     p$unpack(1:8),
     list(x = list(a = 3, b = 1, c = 2, d = 4),
@@ -28,7 +28,7 @@ test_that("can use a grouped packer with no shared parameters", {
     scalar = c("a", "b", "c", "d"))
   expect_equal(
     p$names(),
-    c("a<x>", "b<x>", "c<x>", "d<x>", "a<y>", "b<y>", "c<y>", "d<y>"))
+    c("a | x", "b | x", "c | x", "d | x", "a | y", "b | y", "c | y", "d | y"))
   expect_equal(p$unpack(1:8),
                list(x = list(a = 1, b = 2, c = 3, d = 4),
                     y = list(a = 5, b = 6, c = 7, d = 8)))
@@ -227,7 +227,7 @@ test_that("Can print a grouped packer", {
   expect_match(res$messages, "<monty_packer_grouped>",
                fixed = TRUE, all = FALSE)
   expect_match(res$messages,
-               "Packing 4 values: 'x<a>', 'y<a>', 'x<b>', and 'y<b>",
+               "Packing 4 values: 'x | a>', 'y | a>', 'x | b>', and 'y | b",
                fixed = TRUE, all = FALSE)
 })
 

--- a/tests/testthat/test-packer-grouped.R
+++ b/tests/testthat/test-packer-grouped.R
@@ -227,7 +227,7 @@ test_that("Can print a grouped packer", {
   expect_match(res$messages, "<monty_packer_grouped>",
                fixed = TRUE, all = FALSE)
   expect_match(res$messages,
-               "Packing 4 values: 'x | a>', 'y | a>', 'x | b>', and 'y | b",
+               "Packing 4 values: 'x | a', 'y | a', 'x | b', and 'y | b",
                fixed = TRUE, all = FALSE)
 })
 

--- a/tests/testthat/test-packer-grouped.R
+++ b/tests/testthat/test-packer-grouped.R
@@ -236,8 +236,11 @@ test_that("process can't duplicate existing var with grouped packer", {
   process <- function(res) {
     list(x = res$x + res$y)
   }
+  
+  packer <- monty_packer_grouped(c("a", "b"), c("x", "y"), process = process)
+  
   expect_error(
-    monty_packer_grouped(c("a", "b"), c("x", "y"), process = process),
+    packer$unpack(1:4),
     "'process\\(\\)' is trying to overwrite")
 })
 

--- a/tests/testthat/test-packer.R
+++ b/tests/testthat/test-packer.R
@@ -56,8 +56,9 @@ test_that("can use integer vectors for array inputs", {
 
 
 test_that("can create packer with only arrays", {
-  xp <- monty_packer(array = list(a = 2, b = 3))
-  expect_equal(xp$unpack(1:5), list(a = 1:2, b = 3:5))
+  xp <- monty_packer(array = list(a = 2, b = 3, c = c(2, 2)))
+  expect_equal(xp$unpack(1:9), list(a = 1:2, b = 3:5, c = array(6:9, c(2, 2))))
+  expect_equal(xp$index(), xp$unpack(1:9))
 })
 
 


### PR DESCRIPTION
This is starting point of dealing with grouped/nested models by dealing with some largely internal changes to the packer. Note that this merges into groups-main, which we will ultimately merge into main.

The key point is changing how grouped parameters will be named. We have a grouped packer already on main. Suppose we have groups `a` and `b` and then we have three parameters in each group `alpha`, `beta` and `gamma` where the first two are scalar and `gamma` is a 2x2 matrix. Suppose further that `beta` is shared across the two groups (it has the same value across the two groups) while the others vary between groups. We set the packer up as

```
packer <- monty::monty_packer_grouped(groups = c("a", "b"),
                                      scalar = c("alpha", "beta"),
                                      array = list(gamma = c(2, 2)),
                                      shared = "beta")
```
which leads to parameter names
```
> packer$names()
 [1] "beta"          "alpha<a>"      "gamma[1,1]<a>" "gamma[2,1]<a>" "gamma[1,2]<a>" "gamma[2,2]<a>"
 [7] "alpha<b>"      "gamma[1,1]<b>" "gamma[2,1]<b>" "gamma[1,2]<b>" "gamma[2,2]<b>"
 ```

However for groups we cannot use something like `<group>` as syntax in the DSL. In the DSL we will write
`alpha | group` to signify a parameter to vary between groups. So here I change the names of the parameters to be consistent with that
```
> packer$names()
 [1] "beta"           "alpha | a"      "gamma[1,1] | a" "gamma[2,1] | a" "gamma[1,2] | a"
 [6] "gamma[2,2] | a" "alpha | b"      "gamma[1,1] | b" "gamma[2,1] | b" "gamma[1,2] | b"
[11] "gamma[2,2] | b"
```


The other bit in this PR is some fixing to the index function in the packer where the index is supposed to just include non-fixed parameters but currently it includes fixed parameters e.g.
```
> packer <- monty::monty_packer_grouped(groups = c("a", "b"),
+                                       scalar = c("alpha", "beta"),
+                                       fixed = list("delta" = 1),
+                                       shared = "beta")
> packer$index()
$a
$a$alpha
[1] 2

$a$beta
[1] 1

$a$delta
[1] 1


$b
$b$alpha
[1] 3

$b$beta
[1] 1

$b$delta
[1] 1
```    
with the fix we now get
```
> packer$index()
$a
$a$alpha
[1] 2

$a$beta
[1] 1


$b
$b$alpha
[1] 3

$b$beta
[1] 1
```
which deals with https://github.com/mrc-ide/monty/issues/141                                  